### PR TITLE
Reduce empty vertical space

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -8,13 +8,13 @@
 
 html {
   font-size: 100%;
-  padding-top: 60px;
 }
 
 body {
   font-family: 'Source Sans Pro', sans-serif;
   line-height: 1.45;
-  margin: 0;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 p {
@@ -22,7 +22,7 @@ p {
 }
 
 h1, h2, h3, h4 {
-  margin: 1.414em 0 0.5em;
+  margin: 1em 0 0.5em;
   line-height: 1.2;
   font-weight: bold;
   color: #737475;
@@ -66,7 +66,7 @@ tr:nth-child(even) {
   margin: 0 auto;
   position: relative;
   max-width: 1000px;
-  padding: 10px;
+  padding: 0 10px;
 }
 
 .hero {
@@ -74,18 +74,15 @@ tr:nth-child(even) {
   background-color: #efefef;
 }
 
-#navbar {
-  background-color: #737475;
-  padding: 5px;
-  border-top: 4px solid #f7a41d;
-  margin-bottom: 40px;
-  z-index: 1;
+.hero p {
+  display: inline-block;
 }
 
-#navbar #navbar-content {
-  margin: 0 auto;
-  position: relative;
-  max-width: 1000px;
+#navbar {
+  background-color: #737475;
+  padding: 5px 0;
+  border-top: 4px solid #f7a41d;
+  margin-bottom: 40px;
 }
 
 #navbar .navbar-item, #navbar .navbar-item:visited {

--- a/www/index.html
+++ b/www/index.html
@@ -16,7 +16,7 @@
       <a href="/"><img src="zig-logo.svg" id="header-image"></a>
     </div>
     <nav id="navbar">
-      <div id="navbar-content">
+      <div class="container">
         <a href="download/" class="navbar-item">Download &amp; Documentation</a>
         <a href="https://tio.run/##q8pM//8/OT@vuEShuCRFwVbBITO3IL@oREMJyFXStObiKihNUkjLU8hNzMzT0FQoy89MUajmUgACoAK9lNSk0nS98sSiPA2ljNScnHyF8vyinJSYPJDW2v//AQ"
           class="navbar-item">Try It Online</a>


### PR DESCRIPTION
The new style is nice, but I think it has too much empty vertical space, especially when I view it on my phone (Pixel 2).

Changes:
- Removed large top padding in `html`. To compensate, the default top and bottom margins for `body` have been restored.
- Reduced top margin for headers from `1.414em` to `1em`.
- Removed top and bottom padding from `container` class so that its purpose is only for centering. (This matches the functionality for "container" in many CSS libraries.)
- Removed redundant `#navbar-content` since `container` can be used now.
- Made `.hero p` `display: inline-block` so that its padding affects the height of its containing element.

Tested in Chrome, Edge, and Firefox.