### PR TITLE
add missing allocator parameter to errdefer example

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -502,7 +502,7 @@ const Device = struct {
         const device = try allocator.create(Device);
         errdefer allocator.destroy(device);
 
-        device.name = try std.fmt.allocPrint("Device(id={})", id);
+        device.name = try std.fmt.allocPrint(allocator, "Device(id={})", id);
         errdefer allocator.free(device.name);
 
         if (id == 0) return error.ReservedDeviceId;

--- a/www/index.html
+++ b/www/index.html
@@ -580,7 +580,7 @@ dog
         <span class="tok-kw">const</span> device = <span class="tok-kw">try</span> allocator.create(Device);
         <span class="tok-kw">errdefer</span> allocator.destroy(device);
 
-        device.name = <span class="tok-kw">try</span> std.fmt.allocPrint(<span class="tok-str">&quot;Device(id={})&quot;</span>, id);
+        device.name = <span class="tok-kw">try</span> std.fmt.allocPrint(allocator, <span class="tok-str">&quot;Device(id={})&quot;</span>, id);
         <span class="tok-kw">errdefer</span> allocator.free(device.name);
 
         <span class="tok-kw">if</span> (id == <span class="tok-number">0</span>) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.ReservedDeviceId;


### PR DESCRIPTION
The errdefer example was missing the allocator parameter in the call to `allocPrint`.