### PR TITLE
add sizes to images to prevent content jumping around while loading

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -173,7 +173,7 @@
   </head>
   <body>
     <div class="container">
-      <a href="/"><img alt="ZIG" src="zig-logo.svg" id="header-image"></a>
+      <a href="/"><img alt="ZIG" src="zig-logo.svg" id="header-image" width="340" height="90"></a>
     </div>
     <nav id="navbar">
       <div class="container">
@@ -195,7 +195,7 @@
       <h1 id="Sponsors"><a href="#Introduction">Sponsors</a> <a class="hdr" href="#Sponsors">§</a></h1>
       <div class="sponsor">
         <a href="https://www.patreon.com/andrewrk">
-          <img alt="Patreon" src="img/patreon.png" style="width: 200px; margin: 0 auto; display: block; margin-bottom: 6px;">
+          <img alt="Patreon" src="img/patreon.png" style="width: 200px; margin: 0 auto; display: block; margin-bottom: 6px;" width="200" height="100">
         </a>
         <a href="https://www.patreon.com/andrewrk" style="color: black; text-decoration: none">Support Zig for $5/month</a>
       </div>

--- a/www/index.html
+++ b/www/index.html
@@ -173,7 +173,7 @@
   </head>
   <body>
     <div class="container">
-      <a href="/"><img alt="ZIG" src="zig-logo.svg" id="header-image"></a>
+      <a href="/"><img alt="ZIG" src="zig-logo.svg" id="header-image" width="340" height="90"></a>
     </div>
     <nav id="navbar">
       <div class="container">
@@ -195,7 +195,7 @@
       <h1 id="Sponsors"><a href="#Introduction">Sponsors</a> <a class="hdr" href="#Sponsors">§</a></h1>
       <div class="sponsor">
         <a href="https://www.patreon.com/andrewrk">
-          <img alt="Patreon" src="img/patreon.png" style="width: 200px; margin: 0 auto; display: block; margin-bottom: 6px;">
+          <img alt="Patreon" src="img/patreon.png" style="width: 200px; margin: 0 auto; display: block; margin-bottom: 6px;" width="200" height="100">
         </a>
         <a href="https://www.patreon.com/andrewrk" style="color: black; text-decoration: none">Support Zig for $5/month</a>
       </div>


### PR DESCRIPTION
Fixes a small pet peeve of mine: content jumping around while the page loads.

When you specify width and height attributes on img tags, the browser
will reserve the space while the image is loading.