### PR TITLE
fix typo in reflection.zig

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -785,7 +785,7 @@ pub fn main() void {
 }
 
 fn printInfoAboutStruct(comptime T: type) void {
-    const info = @typeInfo(Header);
+    const info = @typeInfo(T);
     inline for (info.Struct.fields) |field| {
         std.debug.warn(
             "{} has a field called {} with type {}\n",

--- a/www/index.html
+++ b/www/index.html
@@ -950,7 +950,7 @@ $ ./generics
 }
 
 <span class="tok-kw">fn</span> <span class="tok-fn">printInfoAboutStruct</span>(<span class="tok-kw">comptime</span> T: <span class="tok-type">type</span>) <span class="tok-type">void</span> {
-    <span class="tok-kw">const</span> info = <span class="tok-builtin">@typeInfo</span>(Header);
+    <span class="tok-kw">const</span> info = <span class="tok-builtin">@typeInfo</span>(T);
     <span class="tok-kw">inline</span> <span class="tok-kw">for</span> (info.Struct.fields) |field| {
         std.debug.warn(
             <span class="tok-str">&quot;{} has a field called {} with type {}\n&quot;</span>,


### PR DESCRIPTION
For `printInfoAboutStruct` to be generic, it should reference `T` rather than the `Header` type. This PR fixes the minor typo.