### PR TITLE
Add viewport meta tag

### DIFF
--- a/src/download/0.3.0/release-notes.html
+++ b/src/download/0.3.0/release-notes.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>0.3.0 Release Notes &middot; The Zig Programming Language</title>
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">

--- a/src/download/0.4.0/release-notes.html
+++ b/src/download/0.4.0/release-notes.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>0.4.0 Release Notes &middot; The Zig Programming Language</title>
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Zig is a general-purpose programming language designed for robustness, optimality, and maintainability.">
     <title>The Zig Programming Language</title>
     <link rel="icon" href="zig-icon.svg">

--- a/www/documentation/0.1.0/index.html
+++ b/www/documentation/0.1.0/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Documentation - The Zig Programming Language</title>
     <link rel="stylesheet" type="text/css" href="highlight/styles/default.css">
     <style type="text/css">

--- a/www/documentation/0.1.1/index.html
+++ b/www/documentation/0.1.1/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Documentation - The Zig Programming Language</title>
     <link rel="stylesheet" type="text/css" href="highlight/styles/default.css">
     <style type="text/css">

--- a/www/documentation/0.3.0/index.html
+++ b/www/documentation/0.3.0/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Documentation - The Zig Programming Language</title>
     <style type="text/css">
       table, th, td {

--- a/www/documentation/0.4.0/index.html
+++ b/www/documentation/0.4.0/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Documentation - The Zig Programming Language</title>
     <style type="text/css">
       body{

--- a/www/download/0.1.1/release-notes.html
+++ b/www/download/0.1.1/release-notes.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>0.1.1 Release Notes &middot; The Zig Programming Language</title>
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">

--- a/www/download/0.2.0/release-notes.html
+++ b/www/download/0.2.0/release-notes.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>0.2.0 Release Notes &middot; The Zig Programming Language</title>
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">

--- a/www/download/0.3.0/release-notes.html
+++ b/www/download/0.3.0/release-notes.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>0.3.0 Release Notes &middot; The Zig Programming Language</title>
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">

--- a/www/download/0.4.0/release-notes.html
+++ b/www/download/0.4.0/release-notes.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>0.4.0 Release Notes &middot; The Zig Programming Language</title>
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">

--- a/www/index.html
+++ b/www/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="description" content="Zig is a general-purpose programming language designed for robustness, optimality, and maintainability.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>The Zig Programming Language</title>
     <link rel="icon" href="zig-icon.svg">
     <style>


### PR DESCRIPTION
Viewport meta tags improve rendering on mobile devices.

`user-scalable=no` was removed from a couple pages because
we serve end users.