### PR TITLE
`build.zig` is not correct for building `mathtest.c`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1012,7 +1012,7 @@ pub fn build(b: *Builder) void {
     const lib = b.addSharedLibrary("mathtest", "mathtest.zig", b.version(1, 0, 0));
 
     const exe = b.addExecutable("test", null);
-    exe.addCSourceFile("test.c", [][]const u8{"-std=c99"});
+    exe.addCSourceFile("test.c", [_][]const u8{"-std=c99"});
     exe.linkLibrary(lib);
     exe.linkSystemLibrary("c");
 

--- a/www/documentation/0.4.0/index.html
+++ b/www/documentation/0.4.0/index.html
@@ -11008,7 +11008,7 @@ int main(int argc, char **argv) {
     <span class="tok-kw">const</span> lib = b.addSharedLibrary(<span class="tok-str">&quot;mathtest&quot;</span>, <span class="tok-str">&quot;mathtest.zig&quot;</span>, b.version(<span class="tok-number">1</span>, <span class="tok-number">0</span>, <span class="tok-number">0</span>));
 
     <span class="tok-kw">const</span> exe = b.addCExecutable(<span class="tok-str">&quot;test&quot;</span>);
-    exe.addCompileFlags([][]<span class="tok-kw">const</span> <span class="tok-type">u8</span>{<span class="tok-str">&quot;-std=c99&quot;</span>});
+    exe.addCompileFlags([_][]<span class="tok-kw">const</span> <span class="tok-type">u8</span>{<span class="tok-str">&quot;-std=c99&quot;</span>});
     exe.addSourceFile(<span class="tok-str">&quot;test.c&quot;</span>);
     exe.linkLibrary(lib);
 


### PR DESCRIPTION
in response to:
```
build.zig:7:39: error: expected array type or [_], found slice
    exe.addCSourceFile("math_test.c", [][]const u8{"-std=c99"});
```