### PR TITLE
Fix minor typo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -784,7 +784,7 @@ fn printInfoAboutStruct(comptime T: type) void {
 }
       {#code_end#}
       <p>
-      The Zig Standard Library uses this techinque to implement formatted printing.
+      The Zig Standard Library uses this technique to implement formatted printing.
       Despite being a {#link|Small, simple language#}, Zig's formatted printing is implemented entirely in
       Zig. Meanwhile, in C, compile errors for printf are hard-coded into the compiler. Similarly, in Rust,
       the formatted printing macro is hard-coded into the compiler.

--- a/www/index.html
+++ b/www/index.html
@@ -953,7 +953,7 @@ Header has a field called name with type []const u8
 </code></pre>
 
       <p>
-      The Zig Standard Library uses this techinque to implement formatted printing.
+      The Zig Standard Library uses this technique to implement formatted printing.
       Despite being a <a href="#Small-simple-language">Small, simple language</a>, Zig's formatted printing is implemented entirely in
       Zig. Meanwhile, in C, compile errors for printf are hard-coded into the compiler. Similarly, in Rust,
       the formatted printing macro is hard-coded into the compiler.


### PR DESCRIPTION
Saw this while checking out the docs: `techinque` -> `technique`