### PR TITLE
DragonFlyBSD in support table

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1290,6 +1290,7 @@ All your base are belong to us.</code></pre>
 <th>Windows 8.1+</th>
 <th>FreeBSD 12.0+</th>
 <th>NetBSD 8.0+</th>
+<th>DragonFly&#8203;BSD 5.8+</th>
 <th>UEFI</th>
 </tr>
 </thead>
@@ -1298,6 +1299,7 @@ All your base are belong to us.</code></pre>
 <td>x86_64</td>
 <td>{#link|Tier 1|Tier 1 Support#}</td>
 <td>{#link|Tier 1|Tier 1 Support#}</td>
+<td>{#link|Tier 2|Tier 2 Support#}</td>
 <td>{#link|Tier 2|Tier 2 Support#}</td>
 <td>{#link|Tier 2|Tier 2 Support#}</td>
 <td>{#link|Tier 2|Tier 2 Support#}</td>
@@ -1312,6 +1314,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 </tr>
 <tr>
@@ -1322,6 +1325,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 </tr>
 <tr>
@@ -1333,6 +1337,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>i386</td>
@@ -1342,6 +1347,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 2|Tier 2 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>{#link|Tier 2|Tier 2 Support#}</td>
 </tr>
 <tr>
@@ -1352,6 +1358,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 </tr>
 <tr>
@@ -1363,6 +1370,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>hexagon</td>
@@ -1372,6 +1380,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1383,6 +1392,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>mips64</td>
@@ -1392,6 +1402,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1403,6 +1414,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>sparc</td>
@@ -1412,6 +1424,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1423,6 +1436,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>lanai</td>
@@ -1432,6 +1446,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1443,6 +1458,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>powerpc64</td>
@@ -1452,6 +1468,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1463,6 +1480,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>riscv32</td>
@@ -1472,6 +1490,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 </tr>
 <tr>
@@ -1483,6 +1502,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>nvptx</td>
@@ -1492,6 +1512,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1503,6 +1524,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>r600</td>
@@ -1512,6 +1534,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1523,6 +1546,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>tce</td>
@@ -1532,6 +1556,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1543,6 +1568,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>amdil</td>
@@ -1552,6 +1578,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1563,6 +1590,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>spir</td>
@@ -1572,6 +1600,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1583,6 +1612,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>shave</td>
@@ -1593,6 +1623,7 @@ All your base are belong to us.</code></pre>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>N/A</td>
+<td>N/A</td>
 </tr>
 <tr>
 <td>renderscript</td>
@@ -1602,6 +1633,7 @@ All your base are belong to us.</code></pre>
 <td>N/A</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
 <td>{#link|Tier 4|Tier 4 Support#}</td>
+<td>N/A</td>
 <td>N/A</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Not sure if you want to display this differently, but it reflects the current status for dfly.  Zig is also now in [ravenports](http://www.ravenports.com/), [here](http://ravenports.ironwolf.systems/catalog/bucket_BC/zig/standard/)

This package manager does Linux + FreeBSD aswell, but the freebsd package failed to link for some reason, so just listing dfly+linux in [Package Managers](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)