### PR TITLE
Replaced all occurrences of std.debug.warn on the homepage with std.debug.print

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -422,7 +422,7 @@ test "actually undefined behavior" {
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.warn("Hello, world!\n", .{});
+    std.debug.print("Hello, world!\n", .{});
 }
       {#code_end#}
       <p>
@@ -531,7 +531,7 @@ pub fn main() void {
     const msg = "hello this is dog";
     var it = std.mem.tokenize(msg, " ");
     while (it.next()) |item| {
-        std.debug.warn("{}\n", .{item});
+        std.debug.print("{}\n", .{item});
     }
 }
       {#code_end#}
@@ -600,7 +600,7 @@ const std = @import("std");
 
 pub fn main() void {
     const file = std.fs.cwd().openFile("does_not_exist/foo.txt", .{}) catch |err| label: {
-        std.debug.warn("unable to open file: {}\n", .{err});
+        std.debug.print("unable to open file: {}\n", .{err});
         const stderr = std.io.getStdErr();
         break :label stderr;
     };
@@ -710,9 +710,9 @@ pub fn main() void {
     foo();
     bar();
 
-    std.debug.warn("first one:\n", .{});
+    std.debug.print("first one:\n", .{});
     std.debug.dumpStackTrace(trace1);
-    std.debug.warn("\n\nsecond one:\n", .{});
+    std.debug.print("\n\nsecond one:\n", .{});
     std.debug.dumpStackTrace(trace2);
 }
 
@@ -766,7 +766,7 @@ pub fn main() void {
         .len = 0,
     };
 
-    std.debug.warn("{}\n", .{list.items.len});
+    std.debug.print("{}\n", .{list.items.len});
 }
       {#code_end#}
       {#header_close#}
@@ -788,7 +788,7 @@ pub fn main() void {
 fn printInfoAboutStruct(comptime T: type) void {
     const info = @typeInfo(T);
     inline for (info.Struct.fields) |field| {
-        std.debug.warn(
+        std.debug.print(
             "{} has a field called {} with type {}\n",
             .{
                 @typeName(T),
@@ -927,7 +927,7 @@ pub fn main() !void {
     const device = c.soundio_get_output_device(soundio, default_output_index) orelse return error.OutOfMemory;
     defer c.soundio_device_unref(device);
 
-    std.debug.warn("Output device: {s}\n", .{([*]const u8)(device.*.name)});
+    std.debug.print("Output device: {s}\n", .{([*]const u8)(device.*.name)});
 
     const outstream = c.soundio_outstream_create(device) orelse return error.OutOfMemory;
     defer c.soundio_outstream_destroy(outstream);
@@ -1051,7 +1051,7 @@ pub fn build(b: *Builder) void {
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.warn("Hello, world!\n", .{});
+    std.debug.print("Hello, world!\n", .{});
 }
       {#code_end#}
       <p>Now to build it for x86_64-windows, x86_64-macosx, and aarch64v8-linux:</p>
@@ -1202,7 +1202,7 @@ Next, try `zig build --help` or `zig build run`</code></pre>
 const std = @import("std");
 
 pub fn main() anyerror!void {
-    std.debug.warn("All your base are belong to us.\n");
+    std.debug.print("All your base are belong to us.\n");
 }
       {#endsyntax#}</pre>
       <p class="file">build.zig</p>


### PR DESCRIPTION
Between this and #5634 in the main repo, I think that's all of the occurrences on the site except historical records (release notes and such).