### PR TITLE
Bump tiers to 1 for Wasm freestanding and WASI

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1669,9 +1669,9 @@ All your base are belong to us.</code></pre>
 <tbody>
 <tr>
 <td>wasm32</td>
-<td>{#link|Tier 2|Tier 2 Support#}</td>
+<td>{#link|Tier 1|Tier 1 Support#}</td>
 <td>{#link|Tier 3|Tier 3 Support#}</td>
-<td>{#link|Tier 2|Tier 2 Support#}</td>
+<td>{#link|Tier 1|Tier 1 Support#}</td>
 </tr>
 <tr>
 <td>wasm64</td>

--- a/www/index.html
+++ b/www/index.html
@@ -1852,9 +1852,9 @@ All your base are belong to us.</code></pre>
 <tbody>
 <tr>
 <td>wasm32</td>
-<td><a href="#Tier-2-Support">Tier 2</a></td>
+<td><a href="#Tier-1-Support">Tier 1</a></td>
 <td><a href="#Tier-3-Support">Tier 3</a></td>
-<td><a href="#Tier-2-Support">Tier 2</a></td>
+<td><a href="#Tier-1-Support">Tier 1</a></td>
 </tr>
 <tr>
 <td>wasm64</td>


### PR DESCRIPTION
I hope I'm not too overzealous here, but I'd strongly vote for bumping both freestanding Wasm and WASI to tier 1 since we have full CI coverage for both now.