### PR TITLE
Minor adjustments to Japanese texts

### DIFF
--- a/www/news/statement-regarding-zen-programming-language.html
+++ b/www/news/statement-regarding-zen-programming-language.html
@@ -22,6 +22,10 @@
         color: #666;
       }
 
+      h1:lang(ja), h2:lang(ja), h3:lang(ja), h4:lang(ja) {
+        font-feature-settings: 'palt';
+      }
+
       h1 a, h2 a, h3 a, h4 a {
         text-decoration: none;
         color: #666;

--- a/www/news/statement-regarding-zen-programming-language.html
+++ b/www/news/statement-regarding-zen-programming-language.html
@@ -14,7 +14,7 @@
       p {
         margin: 0.8em 0;
       }
-      
+
       h1, h2, h3, h4 {
         margin: 0.5em 0 0.5em;
         line-height: 1.2;
@@ -23,6 +23,7 @@
       }
 
       h1:lang(ja), h2:lang(ja), h3:lang(ja), h4:lang(ja) {
+        margin: 0.7em 0 0.7em;
         font-feature-settings: 'palt';
       }
 
@@ -30,14 +31,18 @@
         text-decoration: none;
         color: #666;
       }
-      
+
       h1 { font-size: 2.0em; }
-      
+
       h2 { font-size: 1.5em; }
-      
+
       h3 { font-size: 1.25em; }
 
       h4 { font-size: 1.0em; }
+
+      p:lang(ja) {
+        line-height: 1.6;
+      }
 
       a.hdr {
         visibility: hidden;
@@ -49,51 +54,51 @@
       a {
         color: #2A6286;
       }
-      
+
       a:not(:hover) {
         text-decoration: none;
       }
-      
+
       th, td {
         padding: 0.6em;
         text-align: left;
       }
-      
+
       td {
         font-size: 0.96em;
       }
-      
+
       th {
         border-bottom: 2px solid #f2f3f3;
       }
-      
+
       tr:nth-child(even) {
         background: #f2f3f3;
       }
-      
+
       .container {
         margin: 0 auto;
         position: relative;
         max-width: 1000px;
         padding: 0 0.2em;
       }
-      
+
       .hero {
         font-size: 1.4em;
         background-color: #efefef;
       }
-      
+
       .hero p {
         display: inline-block;
       }
-      
+
       #navbar {
         background-color: #737475;
         padding: 5px 0;
         border-top: 4px solid #f7a41d;
         margin-bottom: 30px;
       }
-      
+
       #navbar .navbar-item, #navbar .navbar-item:visited {
         color: white;
         padding-right: 5px;
@@ -127,12 +132,12 @@
         color: #333;
         background: #f8f8f8;
       }
-      
+
       .code {
         font-family: monospace;
         font-size: 0.8em;
       }
-      
+
       .tok-kw {
           color: #333;
           font-weight: bold;
@@ -285,7 +290,7 @@
       </div>
     </nav>
     <div>
-      
+
     </div>
     <div class="container">
       <div class="box">
@@ -317,7 +322,7 @@
       <p>
         開発チームについてのお話をしましょう。「No.5」(すなわちクリストファー・テイト氏) はZigプロジェクトの公共の場であるGitHubとIRCで繰り返し問題のある行動を行ったため、プロジェクトから追放されなければならなくなりました。こうした経緯があることをコネクトフリー社は明らかにしていません。その後、テイト氏は「No.2」をZenコンパイラに取り組ませるために雇いましたが、この契約にあたってプライベートな時間で作られたものも含め「No.2」が書いた全てのコードの所有権がコネクトフリー社にも帰属するという契約内容について<a href="https://github.com/ziglang/zig/pull/2701">適切に明確化することを怠りました</a>。その時以来「No.2」はコネクトフリー社の職を辞めましたが、契約の中に示されている「競業避止義務」条項のために、Zigプロジェクトにしばらくのあいだ貢献することもできません。さらに、テイト氏はいくつかのZigコミュニティで宣伝活動を行い、複数のZigコントリビュータをメール経由でスカウトしようとしていたことが知られています。おそらく「No.2」と同じ契約条件で雇おうとしていたものと考えられます。
       </p>
-      
+
       <p>
         以下内容は私どもの公式ウェブサイトからの引用で、Zigソフトウェア財団の使命です。
       </p>
@@ -330,7 +335,7 @@
 
       <p>
         コネクトフリー社の創設者であるテイト氏は、<a href="https://github.com/ziglang/zig/issues/1530">不完全な技術論</a>により彼自身の行動を正当化しようとすると同時に、契約条項を利用してZigの貢献者がこのオープンソースプロジェクトに更に貢献する事を阻止しています。また、コネクトフリー社のZenはZigを表面的にリブランディングしたものに過ぎません。このようなテイト氏の過去と現在の振舞いから、日本の専門家や会社がこうしたクローズドソース製品に頼り生計をたてようとするのは、私どもの良識としてはお勧めできません。
-      </p> 
+      </p>
 
       <p>
         Zigのオープンな設計プロセスは協調の精神に基づいており、オープンソース開発を通じてのみ達成可能なレベルの技術的な卓越性と<a href="https://ziglang.org/download/0.4.0/release-notes.html">圧倒的</a><a href="https://ziglang.org/download/0.5.0/release-notes.html">な改善</a><a href="https://ziglang.org/download/0.6.0/release-notes.html">スピード</a>の実現を目指しています。Zigをユニークで革新的な言語たらしめる多くの特徴 (comptime, async/await, sentinel終端ポインタ型, エラー型等々) は、こうした設計プロセスを進めた結果生まれたものです。
@@ -395,7 +400,7 @@
       </p>
 
       <p>
-        The many features that make Zig a unique and innovative language (comptime, async/await, sentinel-terminated pointer types, error unions, …) are the result of conducting the design process openly, with a collaborative spirit, and with the ultimate goal of reaching a level of technical excellence and <a href="https://ziglang.org/download/0.4.0/release-notes.html">speed</a> <a href="https://ziglang.org/download/0.5.0/release-notes.html">of</a> <a href="https://ziglang.org/download/0.6.0/release-notes.html">improvement</a> that is only truly achievable in open-source software development. 
+        The many features that make Zig a unique and innovative language (comptime, async/await, sentinel-terminated pointer types, error unions, …) are the result of conducting the design process openly, with a collaborative spirit, and with the ultimate goal of reaching a level of technical excellence and <a href="https://ziglang.org/download/0.4.0/release-notes.html">speed</a> <a href="https://ziglang.org/download/0.5.0/release-notes.html">of</a> <a href="https://ziglang.org/download/0.6.0/release-notes.html">improvement</a> that is only truly achievable in open-source software development.
       </p>
       <p>
         Given all of the above, we invite all Japanese developers interested in writing robust, optimal, and reusable code to join <a href="https://github.com/ziglang/zig/wiki/Community">the global Zig community</a> and enjoy the real deal, without having to pay a single Yen for the privilege.

--- a/www/news/statement-regarding-zen-programming-language.html
+++ b/www/news/statement-regarding-zen-programming-language.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="jp">
+<html lang="ja">
   <head>
     <meta charset="utf-8">
     <title>Zigソフトウェア財団とZenプログラミング言語に関する声明 - News - The Zig Programming Language</title>


### PR DESCRIPTION
 - Fixes the language code of <https://ziglang.org/news/statement-regarding-zen-programming-language.html>. `ja` refers to a language whereas `jp` refers to a country. Therefore the correct value of `lang` would be `ja` or `ja-JP`.
- Enables the use of [proportional widths](https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt) in the headings. This distinction between headings and body texts is similar to how [display typefaces](https://en.wikipedia.org/wiki/Display_typeface) are used in headings in Latin script typography. Examples can be seen in websites such as [Qiita](https://qiita.com/tommy19970714/items/e0ce1701e25e315713c4).
- Increases the line height. Japanese letters (kanjis in particular) are designed to be slightly larger than Latin letters of the same font size. This means the line height needs to be adjusted accordingly or the text will look too dense.