### PR TITLE
Go does not have try/catch exceptions

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -117,7 +117,7 @@ bar();</code></pre>
           so in the above example, <code>c.d</code> might call a function.</li>
         <li>C++, D, and Rust have operator overloading,
           so the <code>+</code> operator might call a function.</li>
-        <li>C++, D, and Go have throw/catch exceptions, so
+        <li>C++ and D have throw/catch exceptions, so
           <code>foo()</code> might throw an exception, and prevent <code>bar()</code> from being called.
         </li>
       </ul>


### PR DESCRIPTION
In go, err is explicitly returned. Though go has some examples of hidden control flow, this is not one of them. Maybe instead you can mention another language like python which does have them, or instead as I have proposed here simply remove Go.