### PR TITLE
nav: Download & Docs => Download

### DIFF
--- a/content/download/_index.en.md
+++ b/content/download/_index.en.md
@@ -1,6 +1,6 @@
 ---
-title: "Downloads & Docs"
-menu_title: "Downloads & Docs"
-mobile_menu_title: "Downloads & Docs"
+title: "Download"
+menu_title: "Download"
+mobile_menu_title: "Download"
 layout: downloads
 ---

--- a/content/download/_index.it.md
+++ b/content/download/_index.it.md
@@ -1,6 +1,6 @@
 ---
-title: "Downloads"
-menu_title: "Downloads"
-mobile_menu_title: "Downloads"
+title: "Download"
+menu_title: "Download"
+mobile_menu_title: "Download"
 layout: downloads
 ---


### PR DESCRIPTION
Reasoning: we already have a Documentation link. It's OK to focus that
item on the navigation bar to being Download specific. People who are
familiar with software releases understand that the Download page will
also link to version-specific documentation.

![image](https://user-images.githubusercontent.com/106511/104399782-5b5b7680-551f-11eb-9a50-21f7c91b71cb.png)
