### PR TITLE
Fix some typos in en pages

### DIFF
--- a/content/learn/_index.en.md
+++ b/content/learn/_index.en.md
@@ -23,7 +23,7 @@ A list of useful tools that can help you write Zig code.
 
 
 ## Getting started
-If you're ready to start programming in Zig, this guide will help you setup your enviornment.
+If you're ready to start programming in Zig, this guide will help you setup your environment.
 
 - [Getting started]({{< ref "getting-started.md" >}})  
 

--- a/content/learn/getting-started.en.md
+++ b/content/learn/getting-started.en.md
@@ -6,7 +6,7 @@ toc: true
 
 {{% div class="box thin"%}}
 **<center>Note for Apple Silicon users</center>**
-Zig has experimental support for codesigning. You will be able to use Zig with your M1 Mac,
+Zig has experimental support for code signing. You will be able to use Zig with your M1 Mac,
 but the only way at the moment to get Zig for arm64 macOS is to compile it yourself.
 Make sure to check the [Building from source](#building-from-source) section.
 {{% /div %}}
@@ -31,7 +31,7 @@ extract it in a directory and add it to your `PATH` to be able to call `zig` fro
 
 #### Setting up PATH on Windows
 To setup your path on Windows run **one** of the following snippets of code in a Powershell instance.
-Choose if you want to apply this change on a system-wide level (requires running Powershell with admin priviledges)
+Choose if you want to apply this change on a system-wide level (requires running Powershell with admin privileges)
 or just for your user, and **make sure to change the snippet to point at the location where your copy of Zig lies**.
 The `;` before `C:` is not a typo.
 
@@ -101,11 +101,11 @@ you can find an updated list but keep in mind that some packages might bundle ou
 you can find more information on how to build Zig from source for Linux, macOS and Windows.
 
 ## Recommended tools
-### Syntax Higlighters and LSP
+### Syntax Highlighters and LSP
 All major text editors have syntax highlight support for Zig. 
 Some bundle it, some others require installing a plugin.  
 
-If you're interested in a deeper integration beween Zig and your editor, 
+If you're interested in a deeper integration between Zig and your editor, 
 checkout [zigtools/zls](https://github.com/zigtools/zls).
 
 If you're interested in what else is available, checkout the [Tools](../tools/) section.

--- a/content/news/website-i18n-redesign.md
+++ b/content/news/website-i18n-redesign.md
@@ -11,7 +11,7 @@ make the website pleasing to the eye on various screen sizes and
 color scheme preferences as well as friendlier to programmers with
 a wider range of backgrounds.
 
-I watched Loris perform due dilligence by carefully choosing which
+I watched Loris perform due diligence by carefully choosing which
 aspects from established programming language websites to copy, and
 which aspects to omit for Zig. But even more importantly,
 he actively sought feedback from various Zig communities and made

--- a/content/zsf/index.en.md
+++ b/content/zsf/index.en.md
@@ -35,10 +35,10 @@ Make sure to check your local law to see if you can deduct donations from your t
 
 ### Additional donation methods supported
 - Physical checks (see the snail mail address listed above)
-- Bank trasfers (including from outside of the US, contact us for more info)
+- Bank transfers (including from outside of the US, contact us for more info)
 - [Benevity](https://benevity.com) (recommended if your employer matches donations!)
 
-**Please don't esitate to contact us at donations@ziglang.org if you have questions or specific needs.**
+**Please don't hesitate to contact us at donations@ziglang.org if you have questions or specific needs.**
 
 ## Corporate sponsors
 


### PR DESCRIPTION
Noticed the ZSF page accidentally a few letters, so ran through the site with `contenteditable spellcheck="true"` on, might have missed some others.