### PR TITLE
samples: print to stdout in ziggzagg

### DIFF
--- a/assets/zig-code/samples/3-ziggzagg.zig
+++ b/assets/zig-code/samples/3-ziggzagg.zig
@@ -1,12 +1,18 @@
 // zig-doctest: run --name zag
 const std = @import("std");
 
-pub fn main() void {
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
     var i: usize = 1;
     while (i <= 16) : (i += 1) {
-        if (i % 15 == 0) std.log.info("ZiggZagg", .{}) //
-        else if (i % 3 == 0) std.log.info("Zigg", .{}) //
-        else if (i % 5 == 0) std.log.info("Zagg", .{}) //
-        else std.log.info("{d}", .{i});
+        if (i % 15 == 0) {
+            try stdout.writeAll("ZiggZagg\n");
+        } else if (i % 3 == 0) {
+            try stdout.writeAll("Zigg\n");
+        } else if (i % 5 == 0) {
+            try stdout.writeAll("Zagg\n");
+        } else {
+            try stdout.print("{d}\n", .{i});
+        }
     }
 }


### PR DESCRIPTION
This program is not logging about some other function it is preforming,
its sole purpose is to output text and so this should go to stdout.

Also make the formatting less unusual by removing the empty comments
and adding braces.

cc @pfgithub I believe you are the original author.