### PR TITLE
Add German Translations

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -53,3 +53,5 @@ DefaultContentLanguage = "en"
     weight = 2
   [languages.zh]
     weight = 2
+  [languages.de]
+    weight = 2

--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -2,7 +2,7 @@
 title: Home
 mobile_menu_title: "Home"
 ---
-{{< slogan get_started="EINFÜHRUNG" docs="Dokumentation" notes="Änderungen">}}
+{{< slogan get_started="EINFÜHRUNG" docs="Dokumentation" notes="Änderungen" lang="de">}}
 Zig ist eine General-Purpose-Programmiersprache und Toolchain für **robuste**, **optimale** und **wiederverwendbare** Software.  
 {{< /slogan >}}
 
@@ -129,7 +129,6 @@ Dank vieler Unterstützer ist das Projekt der Open-Source-Community und nicht Ak
 Dieser Abschnitt wird zu Beginn jedes Monats aktualisiert.
 {{% /div %}}
 {{< /div >}}
-
 
 
 

--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -21,14 +21,14 @@ Eine moderner Ansatz zur Metaprogrammierung -- basierend auf Compile-Zeit-Ausfü
 
 - Rufe jede Funktion zur Compile-Zeit auf.
 - Manipuliere Typen als Werte, ohne Laufzeit-Overhead.
-- Comptime emuliert die Targetarchitektur.
+- Comptime emuliert die Zielarchitektur.
 
 # ⚡ Performance trifft Sicherheit
-Schreibe schnellen, klaren Code, der mit allen Fehlerbedingungen umgehen kann.
+Schreibe schnellen und klaren Code, der mit allen Fehlerbedingungen umgehen kann.
 
-- Die Sprache leitet die Fehlerbehandlungslogik elegant.
-- Konfigurierbare Laufzeitüberprüfungen helfen, zwischen Performance und Sicherheitsgarantien abzuwägen.
-- Nutze Vektortypen, um SIMD-Anweisungen portabel auszudrücken.
+- Die Sprache hilft dir dabei, korrekte Fehlerbehandlungen zu schreiben.
+- Konfigurierbare Laufzeitüberprüfungen helfen, einen guten Kompromiss zwischen Performance und Sicherheitsgarantien zu finden.
+- Nutze Vektortypen, um SIMD-Anweisungen plattformunabhängig auszudrücken.
 
 {{% flexrow style="justify-content:center;" %}}
 {{% div %}}
@@ -62,7 +62,7 @@ Schreibe schnellen, klaren Code, der mit allen Fehlerbedingungen umgehen kann.
 {{% div class="community-message" %}}
 # Die Zig-Community ist dezentralisiert
 Jeder darf einen Raum für die Community schaffen.
-Es gibt kein "offiziell" or "inoffiziell", aber jeder Versammlungsort hat seine Regeln und Moderatoren.
+Es gibt kein "offiziell" or "inoffiziell", aber jeder Versammlungsort hat seine eigenen Regeln und Moderatoren.
 
 <div style="">
 <h1>
@@ -76,7 +76,7 @@ Es gibt kein "offiziell" or "inoffiziell", aber jeder Versammlungsort hat seine 
 {{< flexrow class="container" style="justify-content: center;" >}}
 {{% div class="main-development-message" %}}
 # Entwicklung
-Das Zig-Repository ist unter [https://github.com/ziglang/zig](https://github.com/ziglang/zig) zu finden, wo wir auch den Issue-Tracker unterhalten und Vorschläge diskutieren.  
+Das Zig-Repository ist unter [https://github.com/ziglang/zig](https://github.com/ziglang/zig) zu finden, wo wir auch den Issue-Tracker betreiben und Vorschläge diskutieren.  
 Mitwirkende müssen sich an Zigs [Code of Conduct](https://github.com/ziglang/zig/blob/master/CODE_OF_CONDUCT.md) halten.
 {{% /div %}}
 {{% div style="width:40%" %}}

--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -1,0 +1,155 @@
+---
+title: Home
+mobile_menu_title: "Home"
+---
+{{< slogan get_started="EINFÜHRUNG" docs="Dokumentation" notes="Änderungen">}}
+Zig ist eine General-Purpose-Programmiersprache und Toolchain für **robuste**, **optimale** und **wiederverwendbare** Software.  
+{{< /slogan >}}
+
+{{< flexrow class="container" style="padding: 20px 0; justify-content: space-between;" >}}
+{{% div class="features" %}}
+
+# ⚡ Eine einfache Sprache
+Debugge deine Anwendung, nicht deine Kenntnis der Sprache.
+
+- Kein versteckter Kontrollfluss.
+- Keine versteckten Speicherallokationen.
+- Kein Präprozessor, keine Makros. 
+
+# ⚡ Comptime
+Eine moderner Ansatz zur Metaprogrammierung -- basierend auf Compile-Zeit-Ausführung and Lazy Evaluation.
+
+- Rufe jede Funktion zur Compile-Zeit auf.
+- Manipuliere Typen als Werte, ohne Laufzeit-Overhead.
+- Comptime emuliert die Targetarchitektur.
+
+# ⚡ Performance trifft Sicherheit
+Schreibe schnellen, klaren Code, der mit allen Fehlerbedingungen umgehen kann.
+
+- Die Sprache leitet die Fehlerbehandlungslogik elegant.
+- Konfigurierbare Laufzeitüberprüfungen helfen, zwischen Performance und Sicherheitsgarantien abzuwägen.
+- Nutze Vektortypen, um SIMD-Anweisungen portabel auszudrücken.
+
+{{% flexrow style="justify-content:center;" %}}
+{{% div %}}
+<h1>
+    <a href="learn/overview/" class="button" style="display: inline;">Ausführliche Übersicht</a>
+</h1>
+{{% /div %}}
+{{% div  style="margin-left: 5px;" %}}
+<h1>
+    <a href="learn/samples/" class="button" style="display: inline;">Mehr Codebeispiele</a>
+</h1>
+{{% /div %}}
+{{% /flexrow %}}
+{{% /div %}}
+{{< div class="codesample" >}}
+
+{{% zigdoctest "assets/zig-code/index.zig" %}}
+
+{{< /div >}}
+{{< /flexrow >}}
+
+
+{{% div class="alt-background" %}}
+{{% div class="container"  style="display:flex;flex-direction:column;justify-content:center;text-align:center; padding: 20px 0;" title="Community" %}}
+
+{{< flexrow class="container" style="justify-content: center;" >}}
+{{% div style="width:25%" %}}
+<img src="https://raw.githubusercontent.com/ziglang/logo/master/ziggy.svg" style="max-height: 200px">
+{{% /div %}}
+
+{{% div class="community-message" %}}
+# Die Zig-Community ist dezentralisiert
+Jeder darf einen Raum für die Community schaffen.
+Es gibt kein "offiziell" or "inoffiziell", aber jeder Versammlungsort hat seine Regeln und Moderatoren.
+
+<div style="">
+<h1>
+	<a href="https://github.com/ziglang/zig/wiki/Community" class="button" style="display: inline;">Alle Communities ansehen</a>
+</h1>
+</div>
+{{% /div %}}
+{{< /flexrow >}}
+<div style="height: 50px;"></div>
+
+{{< flexrow class="container" style="justify-content: center;" >}}
+{{% div class="main-development-message" %}}
+# Entwicklung
+Das Zig-Repository ist unter [https://github.com/ziglang/zig](https://github.com/ziglang/zig) zu finden, wo wir auch den Issue-Tracker unterhalten und Vorschläge diskutieren.  
+Mitwirkende müssen sich an Zigs [Code of Conduct](https://github.com/ziglang/zig/blob/master/CODE_OF_CONDUCT.md) halten.
+{{% /div %}}
+{{% div style="width:40%" %}}
+<img src="https://raw.githubusercontent.com/ziglang/logo/master/zero.svg" style="max-height: 200px">
+{{% /div %}}
+{{< /flexrow >}}
+{{% /div %}}
+{{% /div %}}
+
+
+{{% div class="container" style="display:flex;flex-direction:column;justify-content:center;text-align:center; padding: 20px 0;" title="Zig Software Foundation" %}}
+## Die ZSF ist eine 501(c)(3) Non-Profit-Organisation.
+
+Die Zig Software Foundation ist eine Non-Profit-Organisation, die 2020 von Andrew Kelley, dem Schöpfer von Zig, geründet wurde, um die Entwicklung der Sprache zu unterstützen. Momentan bietet die ZSF einigen Kernmitwirkenden konkurrenzfähig bezahlte Arbeit. Wir hoffen, dies künftig witeren Mitwirkenden anbieten zu können.
+
+Die Zig Software Foundation wird von Spenden erhalten.
+
+<h1>
+	<a href="zsf/" class="button" style="display:inline;">Mehr erfahren</a>
+</h1>
+{{% /div %}}
+
+
+{{< div class="alt-background" style="padding: 20px 0;">}}
+{{% div class="container" title="Sponsoren" %}}
+# Unternehmenssponsoren
+Die folgenden Unternehmen bieten der Zig Software Foundation direkte finanzielle Unterstützung.
+
+{{% sponsor-logos "monetary" %}}
+ <a href="https://pex.com" rel="noopener nofollow" target="_blank"><picture>
+   <picture>
+     <source srcset="/pex-white.svg" media="(prefers-color-scheme: dark)">
+     <img src="/pex-dark.svg">
+   </picture>
+ </a>
+{{% /sponsor-logos %}}
+
+# GitHub Sponsoren
+Dank vieler Unterstützer ist das Projekt der Open-Source-Community und nicht Aktionären Rechenschaft schuldig. Insbesondere [unterstützen](zsf/) diese guten Leute Zig mit monatlich $200 oder mehr:
+
+- [Karrick McDermott](https://github.com/karrick)
+- [Raph Levien](https://raphlinus.github.io/)
+- [ryanworl](https://github.com/ryanworl)
+- [Stevie Hryciw](https://www.hryx.net/)
+- [Josh Wolfe](https://github.com/thejoshwolfe)
+- [SkunkWerks, GmbH](https://skunkwerks.at/)
+- [drfuchs](https://github.com/drfuchs)
+- Eleanor Bartle
+
+Dieser Abschnitt wird zu Beginn jedes Monats aktualisiert.
+{{% /div %}}
+{{< /div >}}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/content/download/_index.de.md
+++ b/content/download/_index.de.md
@@ -1,0 +1,6 @@
+---
+title: "Download"
+menu_title: "Download"
+mobile_menu_title: "Download"
+layout: downloads
+---

--- a/content/learn/_index.de.md
+++ b/content/learn/_index.de.md
@@ -13,7 +13,7 @@ Dieser Abschnitt enthält Ressourcen, die hoffentlich helfen, Zigs Philosophie z
 {{% learn_docs %}}
 
 ## Einführung
-Dies sind Einführungen in Zig für Programmierer mit verschiedenen Vorkenntnissen.
+Dies sind Einführungen in Zig für Programmierer mit verschiedenen Vorkenntnissen:
 
 - [Ausführliche Übersicht](overview/)  
 Eine ausführliche Übersicht über Zigs Features aus der Perspektive des Systemprogrammierens.

--- a/content/learn/_index.de.md
+++ b/content/learn/_index.de.md
@@ -13,7 +13,7 @@ Dieser Abschnitt enthält Ressourcen, die hoffentlich helfen, Zigs Philosophie z
 {{% learn_docs %}}
 
 ## Einführung
-Dies sind Einführungen in Zig für Programmierer mit verschiedenen Vorkenntnissen:
+Einige Seiten zum Einstieg in Zig für Programmierer mit verschiedenen Vorkenntnissen:
 
 - [Ausführliche Übersicht](overview/)  
 Eine ausführliche Übersicht über Zigs Features aus der Perspektive des Systemprogrammierens.

--- a/content/learn/_index.de.md
+++ b/content/learn/_index.de.md
@@ -1,0 +1,59 @@
+---
+title: "Lernen"
+menu_title: "Lernen"
+mobile_menu_title: "Lernen"
+toc: false
+layout: single
+---
+
+# Lernen
+Dieser Abschnitt enthält Ressourcen, die hoffentlich helfen, Zigs Philosophie zu verstehen.
+
+## Dokumentation
+{{% learn_docs %}}
+
+## Einführung
+Dies sind Einführungen in Zig für Programmierer mit verschiedenen Vorkenntnissen.
+
+- [Ausführliche Übersicht](overview/)  
+Eine ausführliche Übersicht über Zigs Features aus der Perspektive des Systemprogrammierens.
+- [Warum Zig, wenn es schon C++, D und Rust gibt?](why_zig_rust_d_cpp/)  
+Eine Einführung für C++-, D-, und Rust-Programmierer.
+- [Codebeispiele](samples/)  
+Eine Sammlung von Codeschnipseln, um ein Gefühl für Zig zu bekommen.
+- [Tools](tools/)  
+Eine Liste von Werkzeugen, die beim Schreiben von Zig unterstützen.
+
+
+## Einstieg
+Wenn du bereit bist, in Zig zu programmmieren, hilft diese Anleitung bei der Einrichtung des Systems.
+
+- [Einstieg]({{< ref "getting-started.md" >}})  
+
+## Online-Lernressourcen
+- [Zig Learn](https://ziglearn.org)  
+Eine strukturierte Einführung in Zig von [Sobeston](https://github.com/sobeston).
+
+## Relevante Videos and Blogposts
+- [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  
+Video von [Andrew Kelley](https://andrewkelley.me), das Zig and seine Philosophie vorstellt.
+- [Zig's New Relationship with LLVM](https://kristoff.it/blog/zig-new-relationship-llvm/)  
+Ein Blogpost über den Weg zu einem selbst-hostenden Zig-Compiler, auch vorgestellt in einem [Artikel auf lwn.net](https://lwn.net/Articles/833400/).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/content/learn/getting-started.de.md
+++ b/content/learn/getting-started.de.md
@@ -1,0 +1,139 @@
+---
+title: Einstieg
+mobile_menu_title: "Einstieg"
+toc: true
+---
+
+{{% div class="box thin"%}}
+**<center>Hinweis für Nutzer von Apple Silicon</center>**
+Zigs Unterstützung für Code Signing ist experimentell. Du kannst Zig mit deinem M1 Mac vewenden,
+aber momentan ist der einzige Weg, Zig für arm64 macOS zu bekommen, es selbst zu kompilieren.
+Beachte dazu den Abschnitt [Vom Quellcode kompilieren](#vom-quellcode-kompilieren).
+{{% /div %}}
+
+
+## Release oder Nightly Build?
+Zig hat noch nicht v1.0 erreicht und der aktuelle Release-Zyklus ist an neue Releases von LLVM gebunden, die etwa alle 6 Monate erscheinen.
+In der Praxis **liegen Zigs Releases weit auseinander und werden bei der momentanen Entwicklungsgeschwindigkeit irgendwann veraltet**.
+
+Die getaggten Versionen können verwendet werden, aber wenn du tiefer in Zig einsteigen möchtest, **empfehlen wir, auf ein Nightly Build umzusteigen**, vor allem, weil du so einfacher Hilfe bekommen kannst: der Großteil der Community und Seiten wie 
+[ziglearn.org](https://ziglearn.org) verfolgen aus obigen Gründen den Master-Branch.
+
+Die gute Nachricht ist, dass es sehr einfach ist, von einer Version von Zig auf eine andere umzusteigen, oder sogar mehrere Versionen gleichzeitig zu nutzen: Zigs Releases sind vollständige Archive, die überall im System platziert werden können.
+
+
+## Zig installieren
+### Direkter Download
+Dies ist der einfachste Weg, Zig zu bekommen: nimm ein Paket von der [Downloads](/download)-Seite,
+extrahiere es in ein Verzeichnis und füge es an deinen `PATH` an, um Zig von überall nutzen zu können.
+
+#### Auf Windows den PATH ändern
+Um deine PATH-Variable auf Windows einzustellen, führe **einen** der folgenden Codschnipsel mit Powershell aus.
+Entscheide dich, ob du diese Änderung systemweit durchführen willst (erfordert eine mit Adminrechten ausgeführte Powershell)
+oder nur für deinen Benutzer, und **ändere den Schnipsel, um auf deine Kopie von Zig zu verweisen**.
+Das `;` vor dem `C:` ist kein Tippfehler.
+
+Systemweit (**Admin**-Powershell):
+```
+[Environment]::SetEnvironmentVariable(
+   "Path",
+   [Environment]::GetEnvironmentVariable("Path", "Machine") + ";C:\dein-pfad\zig-windows-x86_64-deine-version",
+   "Machine"
+)
+```
+
+Benutzerweise (Powershell):
+```
+[Environment]::SetEnvironmentVariable(
+   "Path",
+   [Environment]::GetEnvironmentVariable("Path", "User") + ";C:\dein-pfad\zig-windows-x86_64-deine-version",
+   "User"
+)
+```
+Wenn du fertig bist, starte die Powershell neu.
+
+#### Auf Linux, macOS oder BSD den PATH ändern
+Füge das Verzeichnis der zig-Binärdatei zu deiner PATH-Umgebungsvariable hinzu.
+
+Dazu wird meistens eine Zeile an das Startupscript (`.profile`, `.zshrc`, ...) der Shell angefügt:
+```bash
+export PATH=$PATH:~/pfad/von/zig
+```
+Wenn du fertig bist, `source` deine Startupdatei oder starte die Shell neu.
+
+
+
+
+### Paketmanager
+#### Windows
+Zig ist auf [Chocolatey](https://chocolatey.org/packages/zig) verfügbar.
+```
+choco install zig
+```
+
+#### macOS
+
+**Homebrew**  
+HINWEIS: Homebrew hat noch keine Bottle für Apple Silicon. Wenn du einen M1 Mac hast, musst du Zig vom Quellcode kompilieren.
+
+Neuestes Release:
+```
+brew install zig
+```
+
+Neuester Build des Master-Branch:
+```
+brew install zig --HEAD
+```
+
+**MacPorts**
+```
+port install zig
+```
+#### Linux
+Zig ist in vielen Paketmanagern für Linux vertreten. [Hier](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)
+ist eine aktuelle Liste; beachte aber, dass einige Pakete möglicherweise veraltete Versionen von Zig bündeln.
+
+### Vom Quellcode kompilieren
+[Hier](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source) 
+findest du weitere Informationen darüber, wie man Zig für Linux, macOS und Windows vom Quellcode kompiliert.
+
+## Empfohlene Tools
+### Syntaxhighlighter und LSP
+Alle größeren Texteditoren unterstützen Syntaxhighlighting für Zig. 
+Einige bringen dies mit, für andere muss ein Plugin installiert werden.  
+
+Für eine tiefere Integration zwischen Zig und deinem Editor siehe [zigtools/zls](https://github.com/zigtools/zls) und den Abschnitt [Tools](../tools/).
+
+## Hello World ausführen
+Wenn du die Installation erfolgreich abgeschlossen hast, solltest du Zig aus der Shell ausführen können.
+
+Probieren wir das mit deinem ersten Zig-Programm aus!
+
+Wechlse in dein Projektverzeichnis und führe aus:
+```bash
+mkdir hello-world
+cd hello-world
+zig init-exe
+```
+
+Das sollte Folgendes ausgeben:
+```
+info: Created build.zig
+info: Created src/main.zig
+info: Next, try `zig build --help` or `zig build run`
+```
+
+Der Befehl `zig build run` sollte dann das Programm kompilieren und ausführen, was dann
+```
+info: All your codebase are belong to us.
+```
+ausgibt. Glückwunsch, du hast jetzt eine funktionierende Installation von Zig!
+
+## Nächste Schritte
+**Sieh dir auch auch die anderen Ressourcen im Abschnitt [Lernen](../) an**, suche dir die Dokumentation für deine Version (Hinweis: Nightly Builds sollten die `master`-Dokumenatation benutzen) und lies vielleicht [ziglearn.org](https://ziglearn.org).
+
+Zig ist ein junges Projekt, und wir haben leider nicht die Kapazitäten, umfangreiche Dokumentation und Lernmaterialien zu erzeugen. Wenn du feststeckst, kannst du aber auch [einer Zig-Community beitreten](https://github.com/ziglang/zig/wiki/Community), oder Initiativen wie [Zig SHOWTIME](https://zig.show) ansehen.
+
+Wenn dir Zig gefällt und du helfen willst, die Entwicklung voranzutreiben, kannst du [der Zig Software Foundation spenden](../../zsf).
+<img src="../../heart.svg" style="vertical-align:middle; margin-right: 5px">.

--- a/content/learn/getting-started.de.md
+++ b/content/learn/getting-started.de.md
@@ -14,7 +14,7 @@ Beachte dazu den Abschnitt [Zig selbst kompilieren](#zig-selbst-kompilieren).
 
 ## Release oder Nightly Build?
 Zig hat noch nicht die Version 1.0 erreicht und der aktuelle Release-Zyklus ist an neue Releases von LLVM gebunden, die etwa alle 6 Monate erscheinen.
-In der Praxis **liegen Zigs Releases weit auseinander und werden bei der momentanen Entwicklungsgeschwindigkeit irgendwann veraltet**.
+In der Praxis **liegen Zigs Releases weit auseinander und werden bei der momentanen Entwicklungsgeschwindigkeit schnell veraltet**.
 
 Die getaggten Versionen können verwendet werden, aber wenn du tiefer in Zig einsteigen möchtest, **empfehlen wir, auf ein Nightly Build umzusteigen**, vor allem, weil du so einfacher Hilfe bekommen kannst: der Großteil der Community und Seiten wie 
 [ziglearn.org](https://ziglearn.org) verfolgen aus obigen Gründen den Master-Branch.

--- a/content/learn/getting-started.de.md
+++ b/content/learn/getting-started.de.md
@@ -8,18 +8,18 @@ toc: true
 **<center>Hinweis für Nutzer von Apple Silicon</center>**
 Zigs Unterstützung für Code Signing ist experimentell. Du kannst Zig mit deinem M1 Mac vewenden,
 aber momentan ist der einzige Weg, Zig für arm64 macOS zu bekommen, es selbst zu kompilieren.
-Beachte dazu den Abschnitt [Vom Quellcode kompilieren](#vom-quellcode-kompilieren).
+Beachte dazu den Abschnitt [Zig selbst kompilieren](#zig-selbst-kompilieren).
 {{% /div %}}
 
 
 ## Release oder Nightly Build?
-Zig hat noch nicht v1.0 erreicht und der aktuelle Release-Zyklus ist an neue Releases von LLVM gebunden, die etwa alle 6 Monate erscheinen.
+Zig hat noch nicht die Version 1.0 erreicht und der aktuelle Release-Zyklus ist an neue Releases von LLVM gebunden, die etwa alle 6 Monate erscheinen.
 In der Praxis **liegen Zigs Releases weit auseinander und werden bei der momentanen Entwicklungsgeschwindigkeit irgendwann veraltet**.
 
 Die getaggten Versionen können verwendet werden, aber wenn du tiefer in Zig einsteigen möchtest, **empfehlen wir, auf ein Nightly Build umzusteigen**, vor allem, weil du so einfacher Hilfe bekommen kannst: der Großteil der Community und Seiten wie 
 [ziglearn.org](https://ziglearn.org) verfolgen aus obigen Gründen den Master-Branch.
 
-Die gute Nachricht ist, dass es sehr einfach ist, von einer Version von Zig auf eine andere umzusteigen, oder sogar mehrere Versionen gleichzeitig zu nutzen: Zigs Releases sind vollständige Archive, die überall im System platziert werden können.
+Die gute Nachricht ist, dass es sehr einfach ist, von einer Version von Zig auf eine andere umzusteigen, oder sogar mehrere Versionen gleichzeitig zu nutzen: Zigs Releases sind einfach Archive, die alles Notwendige enthalten und überall im System platziert werden können.
 
 
 ## Zig installieren
@@ -59,7 +59,7 @@ Dazu wird meistens eine Zeile an das Startupscript (`.profile`, `.zshrc`, ...) d
 ```bash
 export PATH=$PATH:~/pfad/von/zig
 ```
-Wenn du fertig bist, `source` deine Startupdatei oder starte die Shell neu.
+Wenn du fertig bist, rufe `source` mit deiner Startupdatei auf oder starte die Shell neu.
 
 
 
@@ -74,7 +74,7 @@ choco install zig
 #### macOS
 
 **Homebrew**  
-HINWEIS: Homebrew hat noch keine Bottle für Apple Silicon. Wenn du einen M1 Mac hast, musst du Zig vom Quellcode kompilieren.
+HINWEIS: Homebrew hat noch keine Bottle für Apple Silicon. Wenn du einen M1 Mac hast, musst du Zig selbst kompilieren.
 
 Neuestes Release:
 ```
@@ -91,19 +91,19 @@ brew install zig --HEAD
 port install zig
 ```
 #### Linux
-Zig ist in vielen Paketmanagern für Linux vertreten. [Hier](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)
-ist eine aktuelle Liste; beachte aber, dass einige Pakete möglicherweise veraltete Versionen von Zig bündeln.
+Zig ist in vielen Paketmanagern für Linux verfügbar. [Hier](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)
+ist eine aktuelle Liste; beachte aber, dass einige Pakete möglicherweise veraltete Versionen von Zig enthalten.
 
-### Vom Quellcode kompilieren
+### Zig selbst kompilieren
 [Hier](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source) 
-findest du weitere Informationen darüber, wie man Zig für Linux, macOS und Windows vom Quellcode kompiliert.
+findest du weitere Informationen darüber, wie man Zig für Linux, macOS und Windows selbst kompiliert.
 
 ## Empfohlene Tools
 ### Syntaxhighlighter und LSP
 Alle größeren Texteditoren unterstützen Syntaxhighlighting für Zig. 
 Einige bringen dies mit, für andere muss ein Plugin installiert werden.  
 
-Für eine tiefere Integration zwischen Zig und deinem Editor siehe [zigtools/zls](https://github.com/zigtools/zls) und den Abschnitt [Tools](../tools/).
+Wenn du Zig besser mit deinem Editor integrieren möchtest, schau dir [zigtools/zls](https://github.com/zigtools/zls) und den Abschnitt [Tools](../tools/) an.
 
 ## Hello World ausführen
 Wenn du die Installation erfolgreich abgeschlossen hast, solltest du Zig aus der Shell ausführen können.

--- a/content/learn/getting-started.de.md
+++ b/content/learn/getting-started.de.md
@@ -136,4 +136,4 @@ ausgibt. Glückwunsch, du hast jetzt eine funktionierende Installation von Zig!
 Zig ist ein junges Projekt, und wir haben leider nicht die Kapazitäten, umfangreiche Dokumentation und Lernmaterialien zu erzeugen. Wenn du feststeckst, kannst du aber auch [einer Zig-Community beitreten](https://github.com/ziglang/zig/wiki/Community), oder Initiativen wie [Zig SHOWTIME](https://zig.show) ansehen.
 
 Wenn dir Zig gefällt und du helfen willst, die Entwicklung voranzutreiben, kannst du [der Zig Software Foundation spenden](../../zsf).
-<img src="../../heart.svg" style="vertical-align:middle; margin-right: 5px">.
+<img src="/heart.svg" style="vertical-align:middle; margin-right: 5px">.

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -1,0 +1,589 @@
+---
+title: "Ausführliche Übersicht"
+mobile_menu_title: "Übersicht"
+toc: true
+---
+# Feature Highlights
+## Kleine, einfache Sprache
+Debugge deine Anwendung, nicht deine Kenntnis der Programmiersprache.
+
+Zig's gesamte Syntax ist in 500 Zeilen [PEG-Grammatik](https://ziglang.org/documentation/master/#Grammar) beschrieben.
+
+Es gibt **keinen verstecketen Kontrollfluss**, keine versteckten Speicherallokationen, keinen Präprozessor, und keine Makros. Wenn Zig kode nicht aussieht, als ober in einen Funktionsaufruf springt, dann tut er das nicht. Das bedeutet, dass du sicher sein kannst, dass der folgende Code nur `foo()` und dann `bar()` aufruft, und das ist garantiert, ohne die Typen von irgendwelchen Werten zu kennen:
+
+```zig
+var a = b + c.d;
+foo();
+bar();
+```
+
+Beispiele von verstecketem Kontrollfluss:
+
+- D hat `@property`-Funktionen -- Methoden, deren Aufruf wie ein Feldzugriff aussieht, also könnte im obigen Beispiel `c.d` eine Funktion aufrufen.
+- C++, D, und Rust haben Operatorenüberladung, also könnte der Operator `+` eine Funktion aufrufen.
+- C++, D, und Go haben throw/catch-Ausnahmen, also könnte `foo()` eine Ausahme werfen und die Ausführung von `bar()` verhindern.
+
+ Zig fördert Codewartung und Lesbarkeit, indem Kontrollfluss ausschließlich mit Schlüsselwörtern und Funktionsaufrufen geschieht.
+
+## Performance und Sicherheit: wähle zwei
+
+Zig hat vier [Buildmodi](https://ziglang.org/documentation/master/#Build-Mode), sie können [Scope-weise](https://ziglang.org/documentation/master/#setRuntimeSafety) kombiniert werden.
+
+| Parameter | [Debug](/documentation/master/#Debug) | [ReleaseSafe](/documentation/master/#ReleaseSafe) | [ReleaseFast](/documentation/master/#ReleaseFast) | [ReleaseSmall](/documentation/master/#ReleaseSmall) |
+|-----------|-------|-------------|-------------|--------------|
+Optimierungen - bessere Geschwindigkeit,<br /> schlechteres Debugging und Compilierdauer | | -O3 | -O3| -Os |
+Laufzeitsicherheitschecks - schlechtere Geschwindigkeit <br />und Programmgröße, Crashes statt undefiniertem Verhalten | On | On | | |
+
+So sieht [Integer Overflow](https://ziglang.org/documentation/master/#Integer-Overflow) zur Compilezeit aus, in jedem Buildmodus:
+
+{{< zigdoctest "assets/zig-code/features/1-integer-overflow.zig" >}}
+
+So sieht er zur Laufzeit aus, in safety-checked builds:
+
+{{< zigdoctest "assets/zig-code/features/2-integer-overflow-runtime.zig" >}}
+
+
+Die [Stacktraces funktionieren auf allen Targets](#stacktraces-auf-allen-targets), auch [freestanding](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html).
+
+Zig erlaubt es, sich auf einen Buildmodus mit aktivierter Sicherheit verlassen, und die Sicherheit an performance-bottlenecks selektiv zu deaktivieren. Das vorherige Beispiel könnte so verändert werden:
+
+{{< zigdoctest "assets/zig-code/features/3-undefined-behavior.zig" >}}
+
+Zig benutzt [undefniniertes Verhalten](https://ziglang.org/documentation/master/#Undefined-Behavior) als ein  messerscharfes Instrument zur Vermeidung von Bugs und Performanceverbesserung.
+
+Apropos Performance: Zig ist schneller als C.
+
+- Die Referenzimplementierung nutzt LLVM als Backend für Optimierungen auf dem neuesten Stand der Technik.
+- Was andere Sprachen "Link Time Optimization" nennen, tut Zig automatisch.
+- Für native Targets sind moderne CPU-Features aktiviert (`-march=native`), denn [Crosscompiling ist ein primärer Einsatzfall](#crosscompiling-ist-ein-primärer-einsatzfall).
+- Sorgfältig ausgewähltes undefiniertes Verhalten. Zum Beispiel haben in Zig sowohl signed und unsigned Integers undefiniertes Verhalten beim Überlauf, was in C nur bei signed Integers der Fall ist. Das [ermöglicht Optimierungen, die in C nicht möglich sind](https://godbolt.org/z/n_nLEU).
+- Zig stellt einen [Vektortyp für SIMD](https://ziglang.org/documentation/master/#Vectors) zur Verfügung, der es einfach macht, portablen vektorisierten Code zu schreiben.
+
+Beachte bitte, dass Zig keine vollständig sichere Sprache ist. Interessierte an der Geschichte von Zigs Sicherheit können diese Issues abbonieren:
+
+- [enumerate all kinds of undefined behavior, even that which cannot be safety-checked](https://github.com/ziglang/zig/issues/1966)
+- [make Debug and ReleaseSafe modes fully safe](https://github.com/ziglang/zig/issues/2301)
+
+## Zig ist nicht abhängig von C, sondern konkurriert mit C
+
+Zigs Standarsbibliothek kann libc einbeziehen, aber ist nicht darauf angewiesen. Hier ist Hello World:
+
+{{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
+
+Mit `-O ReleaseSmall` kompiliert, ohne Debugsymbole, im Single Thread-Modus, wird für das Target x86_64-linux eine 9.8 KiB große statische Programmdatei erzeugt:
+```
+$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ wc -c hello
+9944 hello
+$ ldd hello
+  not a dynamic executable
+```
+
+Ein Build auf Windows ist noch kleiner, nur 4096 Bytes:
+```
+$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ wc -c hello.exe
+4096 hello.exe
+$ file hello.exe
+hello.exe: PE32+ executable (console) x86-64, for MS Windows
+```
+
+## Deklarationen in beliebiger Reihenfolge
+
+Deklarationen im Toplevel, wie globale Variablen, sind reihenfolgenunabhängig und werden nur bei Bedarf ausgewertet. Die Initialisierungswerte globaler Variablen werden [zur Compilezeit ausgewertet](#introspektion-und-codeausführung-zur-compilezeit).
+
+{{< zigdoctest "assets/zig-code/features/5-global-variables.zig" >}}
+
+## Optionale Typen statt Nullpointer
+
+In anderen Programmiersprachen sind Nullzeiger die Quelle vieler Laufzeitprobleme, und werden sogar beschuldigt, [der schlimmste Fehler der Computerwissenwschaft](https://www.lucidchart.com/techblog/2015/08/31/the-worst-mistake-of-computer-science/) zu sein.
+
+Rohe Pointer können in Zig nicht Null sein:
+
+{{< zigdoctest "assets/zig-code/features/6-null-to-ptr.zig" >}}
+
+Jedoch kann jeder Typ durch ein vorgestelltes ? in einen [optionalen Typ](https://ziglang.org/documentation/master/#Optionals) verwandelt werden:
+
+{{< zigdoctest "assets/zig-code/features/7-optional-syntax.zig" >}}
+
+Um einen optionalen Typ zu entpacken, kann ein `orelse` verwendet werden, um einen Default-Wert anzugeben:
+
+{{< zigdoctest "assets/zig-code/features/8-optional-orelse.zig" >}}
+
+Stattdessen kann auch ein if verwendet werden:
+
+{{< zigdoctest "assets/zig-code/features/9-optional-if.zig" >}}
+
+Dieselbe Syntax funktioniert mit [while](https://ziglang.org/documentation/master/#while):
+
+{{< zigdoctest "assets/zig-code/features/10-optional-while.zig" >}}
+
+## Manuelle Speicherverwaltung
+
+Eine in Zig verfasste Bibliothek kann überall verwendet werden:
+
+- [Desktopanwendungen](https://github.com/TM35-Metronome/) & [games](https://github.com/dbandstra/oxid)
+- Server mit geringer Latenz
+- [etriebssystemkernel](https://github.com/AndreaOrru/zen)
+- [Embedded-Geräte](https://github.com/skyfex/zig-nrf-demo/)
+- Echtzeitsoftware, z.B. Liveauftritte, Flugzeuge, Herzschrittmacher
+- [In Webbrowsern oder anderen Plugins mit WebAssembly](https://shritesh.github.io/zigfmt-web/)
+- Mit anderen Programmiersprachen, über die C ABI
+
+Um das zu erreichen, müssen Zig-Programmierer ihren Speicher selbst verwalten und mit scheiternder Speicherallokation umgehen.
+
+Das trifft auch auf die Standardbibliothek zu. Alle Funktionen, die Speicher alloziieren müssen, nehmen einen Allocator als Parameter an. Damit kann die Standardbibliothek sogar auf dem Freestanding-Target verwendet werden.
+
+Außer einem [neuen Ansatz zur Fehlerbehandlung](#ein-neuer-ansatz-zur-fehlerbehandlung), stellt Zig [defer](https://ziglang.org/documentation/master/#defer) und [errdefer](https://ziglang.org/documentation/master/#errdefer) zur Verfügung, um alle Ressourcenverwaltung -- nicht nur Speicher -- einfach und leicht verifizierbar zu machen.
+
+Für Beispiele von `defer`, siehe [Integration mit C-Bibliotheken ohne FFI/Bindings](#integration-mit-c-bibliotheken-ohne-ffibindings). Hier ist ein Beispiel von `errdefer`:
+{{< zigdoctest "assets/zig-code/features/11-errdefer.zig" >}}
+
+
+## Ein neuer Ansatz zur Fehlerbehandlung
+
+Fehler sind Werte, und können nicht ignoriert werden:
+
+{{< zigdoctest "assets/zig-code/features/12-errors-as-values.zig" >}}
+
+Fehler können mit [catch](https://ziglang.org/documentation/master/#catch) verarbeitet werden:
+
+{{< zigdoctest "assets/zig-code/features/13-errors-catch.zig" >}}
+
+Das Schlüsselwort [try](https://ziglang.org/documentation/master/#try) ist eine Abkürzung für `catch |err| return err`:
+
+{{< zigdoctest "assets/zig-code/features/14-errors-try.zig" >}}
+
+Bemerke, dass das ein [Error Return Trace](https://ziglang.org/documentation/master/#Error-Return-Traces) ist, kein [Stacktrace](#stacktraces-auf-allen-targets). Der Code hat nicht den Preis einer Stackabwicklung gezahlt, um den Trace zu erhalten.
+
+Das [switch](https://ziglang.org/documentation/master/#switch)-Schlüsselwort, benutzt mit einem Fehlerwert, stellt sicher, dass alle möglichen Fehler behandelt werden:
+
+{{< zigdoctest "assets/zig-code/features/15-errors-switch.zig" >}}
+
+Das Schlüsselwort [unreachable](https://ziglang.org/documentation/master/#unreachable) kann genutzt werden, um zu versichern, dass kein Fehler auftreten kann:
+
+{{< zigdoctest "assets/zig-code/features/16-unreachable.zig" >}}
+
+Das führt in den ungesicherten Buildmodi zu [undefiniertem Verhalten](#performance-und-sicherheit-wähle-zwei) und sollte nur genutzt werden, wenn der Erfolg wirklich garantiert ist.
+
+### Stacktraces auf allen Targets
+
+Die Stacktraces und [Error Return Trace](https://ziglang.org/documentation/master/#Error-Return-Traces) auf dieser Seite funktionieren für alle Targets mit [Tier 1 Support](#tier-1-support) und einige mit [Tier 2 Support](#tier-2-support). [Sogar Freestanding](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html)!
+
+Außerdem kann die Standardbibliothek an jedem Punkt einen Stacktrace aufzeichnen und später ausgeben:
+
+{{< zigdoctest "assets/zig-code/features/17-stack-traces.zig" >}}
+
+Diese Technik wird für den (in Entwicklung befindlichen) [GeneralPurposeDebugAllocator](https://github.com/andrewrk/zig-general-purpose-allocator/#current-status) verwendet.
+
+## Generische Datenstrukturen und Funktionen
+
+Typen sind Werte, die zur Compilezeit bekannt sein müssen:
+
+{{< zigdoctest "assets/zig-code/features/18-types.zig" >}}
+
+Eine generische Datenstruktur ist einfach eine Funktion, die einen `type` zurückgibt:
+
+{{< zigdoctest "assets/zig-code/features/19-generics.zig" >}}
+
+## Introspektion und Codeausführung zur Compilezeit
+
+Die Builtinfunktion [@typeInfo](https://ziglang.org/documentation/master/#typeInfo) erlaubt Introspektion:
+
+{{< zigdoctest "assets/zig-code/features/20-reflection.zig" >}}
+
+Die Standardbibliothek benutzt diese Technik, um formatierte Ausgabe zu implementieren. Obwohl es eine [kleine, einfache Sprache](#kleine-einfache-sprache) ist, wurde die formatierte Ausgabe vollständig in Zig programmiert. Währenddessen sind die Compilierfehler für `printf` in den C-Compiler und das Formatierungsmakro in den Rust-Compiler hartkodiert.
+
+Zig kann auch Funktionen und Codeblöcke zur Compilezeit auswerten. In einigen Kontexten, wie der Initialisierung von globalen Variablen, geschieht dies implizit. Andernfalls kann Code mit dem Schlüsselwort [comptime](https://ziglang.org/documentation/master/#comptime) explizit zur Compilezeit ausgewertet werden. In Kombination mit Assertions ist dies ein mächtiges Werkzeug:
+
+{{< zigdoctest "assets/zig-code/features/21-comptime.zig" >}}
+
+## Integration mit C-Bibliotheken ohne FFI/Bindings
+
+[@cImport](https://ziglang.org/documentation/master/#cImport) importiert direkt Typen, Variablen, Funktionen und einfache Makros aus C-Bibliotheken und kann sogar Funktionen von C nach Zig übersetzen.
+
+Hier ist ein Beispiel, das mit [libsoundio](http://libsound.io/) ein Sinuswelle ausgibt:
+
+<u>sine.zig</u>
+{{< zigdoctest "assets/zig-code/features/22-sine-wave.zig" >}}
+
+```
+$ zig build-exe sine.zig -lsoundio -lc
+$ ./sine
+Output device: Built-in Audio Analog Stereo
+^C
+```
+
+[Dieser Zigcode ist signifikant einfacher als der äquivalente C-Code](https://gist.github.com/andrewrk/d285c8f912169329e5e28c3d0a63c1d8), hat mehr Sicherheitsvorkehrungen, und all das wird mit einem einfache `@cImport` der C-Headerdateien erreicht -- ohne API-Bindings.
+
+*Zig kann C-Bibliotheken besser nutzen als das C selbst kann.*
+
+### Zig ist auch ein C-Compiler
+
+Hier ist ein Beispiel dafür, wie Zig C-Code kompiliert:
+
+<u>hello.c</u>
+```c
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Hello world\n");
+    return 0;
+}
+```
+
+```
+$ zig build-exe --c-source hello.c --library c
+$ ./hello
+Hello world
+```
+
+Die Flag `--verbose-cc` zeigt, welcher C-Compiler-Befehl ausgeführt wird:
+```
+$ zig build-exe --c-source hello.c --library c --verbose-cc
+zig cc -MD -MV -MF zig-cache/tmp/42zL6fBH8fSo-hello.o.d -nostdinc -fno-spell-checking -isystem /home/andy/dev/zig/build/lib/zig/include -isystem /home/andy/dev/zig/build/lib/zig/libc/include/x86_64-linux-gnu -isystem /home/andy/dev/zig/build/lib/zig/libc/include/generic-glibc -isystem /home/andy/dev/zig/build/lib/zig/libc/include/x86_64-linux-any -isystem /home/andy/dev/zig/build/lib/zig/libc/include/any-linux-any -march=native -g -fstack-protector-strong --param ssp-buffer-size=4 -fno-omit-frame-pointer -o zig-cache/tmp/42zL6fBH8fSo-hello.o -c hello.c -fPIC
+```
+
+Wird der Befehl erneut ausgeführt, bricht er sofort ab, ohne den Compiler aufzurufen:
+```
+$ time zig build-exe --c-source hello.c --library c --verbose-cc
+
+real	0m0.027s
+user	0m0.018s
+sys	0m0.009s
+```
+
+Das geschieht dank dem [Build Artifact Caching](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching). Zig parst automatisch die erzeugte Depfile und benutzt ein robustes Cachesystem, um redundante Arbeit zu vermeiden.
+
+Nicht nur kann Zig C kompilieren, sondern es gibt auch einen sehr guten Grund, Zig als C-Compiler zu nutzen: [Zig enthält libc](#zig-enthält-libc).
+
+### Export von Funktionen, Variablen und Typen für C-Code
+
+Ein primärer Einsatzfall für Zig ist es, eine Bibliothek mit C ABI zu exportieren, die von anderen Sprachen genutzt werden kann. Das Schlüsselwort `export` vor Funktionen, Variablen und Typen macht sie zu einem Teil der API der Bibliothek:
+
+<u>mathtest.zig</u>
+{{< zigdoctest "assets/zig-code/features/23-math-test.zig" >}}
+
+Um eine statische Bibliothek zu erzeugen:
+```
+$ zig build-lib mathtest.zig
+```
+
+Um eine dynamische Bibliothek zu erzeugen:
+```
+$ zig build-lib mathtest.zig -dynamic
+```
+
+Hier ein Beispiel des [Zig-Buildsystems](#zigs-buildsystem):
+
+<u>test.c</u>
+```c
+#include "mathtest.h"
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    int32_t result = add(42, 1337);
+    printf("%d\n", result);
+    return 0;
+}
+```
+
+<u>build.zig</u>
+{{< zigdoctest "assets/zig-code/features/24-build.zig" >}}
+
+```
+$ zig build test
+1379
+```
+
+## Crosscompiling ist ein primärer Einsatzfall
+
+Zig kann für jedes der Targets im [Support Table](#support-table) mit [Tier 3 Support](#tier-3-support) oder besser kompilieren. Dazu muss keine "cross toolchain" oder Ähnliches muss installiert werden. Hier ist ein natives Hello World:
+
+{{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
+
+Und jetzt Builds für x86_64-windows, x86_64-macosx und aarch64v8-linux:
+```
+$ zig build-exe hello.zig -target x86_64-windows
+$ file hello.exe
+hello.exe: PE32+ executable (console) x86-64, for MS Windows
+$ zig build-exe hello.zig -target x86_64-macosx
+$ file hello
+hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
+$ zig build-exe hello.zig -target aarch64v8-linux
+$ file hello
+hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
+```
+
+Das funktioniert auf jedem Target mit [Tier 3](#tier-3-support)+, für jedes Target mit [Tier 3](#tier-3-support)+.
+
+### Zig enthält libc
+
+`zig targets` listet unter anderem die verfügbaren libc-Targets auf:
+```
+...
+ "libc": [
+  "aarch64_be-linux-gnu",
+  "aarch64_be-linux-musl",
+  "aarch64_be-windows-gnu",
+  "aarch64-linux-gnu",
+  "aarch64-linux-musl",
+  "aarch64-windows-gnu",
+  "armeb-linux-gnueabi",
+  "armeb-linux-gnueabihf",
+  "armeb-linux-musleabi",
+  "armeb-linux-musleabihf",
+  "armeb-windows-gnu",
+  "arm-linux-gnueabi",
+  "arm-linux-gnueabihf",
+  "arm-linux-musleabi",
+  "arm-linux-musleabihf",
+  "arm-windows-gnu",
+  "i386-linux-gnu",
+  "i386-linux-musl",
+  "i386-windows-gnu",
+  "mips64el-linux-gnuabi64",
+  "mips64el-linux-gnuabin32",
+  "mips64el-linux-musl",
+  "mips64-linux-gnuabi64",
+  "mips64-linux-gnuabin32",
+  "mips64-linux-musl",
+  "mipsel-linux-gnu",
+  "mipsel-linux-musl",
+  "mips-linux-gnu",
+  "mips-linux-musl",
+  "powerpc64le-linux-gnu",
+  "powerpc64le-linux-musl",
+  "powerpc64-linux-gnu",
+  "powerpc64-linux-musl",
+  "powerpc-linux-gnu",
+  "powerpc-linux-musl",
+  "riscv64-linux-gnu",
+  "riscv64-linux-musl",
+  "s390x-linux-gnu",
+  "s390x-linux-musl",
+  "sparc-linux-gnu",
+  "sparcv9-linux-gnu",
+  "wasm32-freestanding-musl",
+  "x86_64-linux-gnu",
+  "x86_64-linux-gnux32",
+  "x86_64-linux-musl",
+  "x86_64-windows-gnu"
+ ],
+ ```
+
+Das bedeutet, dass `--library c` für diese Targets *von keinerlei Systemdateien abhängt*!
+
+Sehen wir uns  wieder das [Hello World-Beispiel in C](#zig-ist-auch-ein-c-compiler) an:
+```
+$ zig build-exe --c-source hello.c --library c
+$ ./hello
+Hello world
+$ ldd ./hello
+	linux-vdso.so.1 (0x00007ffd03dc9000)
+	libc.so.6 => /lib/libc.so.6 (0x00007fc4b62be000)
+	libm.so.6 => /lib/libm.so.6 (0x00007fc4b5f29000)
+	libpthread.so.0 => /lib/libpthread.so.0 (0x00007fc4b5d0a000)
+	libdl.so.2 => /lib/libdl.so.2 (0x00007fc4b5b06000)
+	librt.so.1 => /lib/librt.so.1 (0x00007fc4b58fe000)
+	/lib/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007fc4b6672000)
+```
+
+Im Gegensatz zu [glibc](https://www.gnu.org/software/libc/) unterstützt [musl](https://www.musl-libc.org/) statische Kompilierung:
+```
+$ zig build-exe --c-source hello.c --library c -target x86_64-linux-musl
+$ ./hello
+Hello world
+$ ldd hello
+  not a dynamic executable
+```
+
+In diesem Beispiel hat Zig musls Quellcode kompiliert und verlinkt. Dank dem [Cachesystem](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching) bleibt das Build von musl-libc für `x86_64-linux` verfügbar und kann bei Bedarf sofort genutzt werden.
+
+Das bedeutet, dass die Funktionalität auf jeder Plattform verfügbar ist. Nutzer von Windows und macOS können Zig- und C-Code für jedes der obigen Targets kompilieren und gegen libc linken. Auf ähnliche Art und Weise kann Code für andere Priozessorarchitekturen crosskompiliert werden:
+```
+$ zig build-exe --c-source hello.c --library c -target aarch64v8-linux-gnu
+$ file hello
+hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
+```
+
+In macher Hinsicht kann Zig besser C kompilieren als C-Compiler!
+
+Diese Funktionalität ist mehr als eine mit Zig gebündelte Cross-Toolchain. Zum Beispiel sind die libc-Header, die Zig mitbringt, unkomprimiert 22 MiB groß. Dabei kommen die Header für musl libc + Linux auf x86_64 alleine auf 8 MiB, und die Header für glibc machen 3.1 MiB aus (glibc fehlen die Linux-Header), aber Zig enthält momentan 40 libcs. Ohne Bündelung wären das 444 MiB. Dank meines Tools [process_headers](https://github.com/ziglang/zig/blob/0.4.0/libc/process_headers.zig) jedoch, und ein wenig [guter alter manueller Arbeit](https://github.com/ziglang/zig/wiki/Updating-libc), bleiben Zigs binäre Tarballs bei insgesamt rund 30 MiB, trotz Unterstützung für libc auf all diesen  Targets, sowie compiler-rt, libunwind und libcxx, und dem Clang-kompatiblen C-Compiler. Zum Vergleich: das Build von clang 8.0.0 von llvm.org für Windows ist 132 MiB groß.
+
+Beachte, dass nur die Targets im [Tier 1 Support](#tier-1-support) ausführlich getestet wurden. Es ist geplant, [mehr libcs](https://github.com/ziglang/zig/issues/514) hinzuzufügen (auch für Windows), und [Testabdeckung für Builds gegen alle libcs](https://github.com/ziglang/zig/issues/2058) zu erreichen.
+
+Ein [Paketmanager für Zig](https://github.com/ziglang/zig/issues/943) ist geplant, aber noch nicht fertig. Damit soll es möglich werden, Pakete für C-Bibliotheken zu erstellen. Dies würde das [Zigs Buildsystem](#zigs-buildsystem) für Zig- und C-Programmierer gleichermaßen attraktiv machen.
+
+## Zigs Buildsystem
+
+Zig enthält ein Buildsystem, das make, cmake oder Ähnliches ersetzen kann.
+```
+$ zig init-exe
+Created build.zig
+Created src/main.zig
+
+Next, try `zig build --help` or `zig build run`
+```
+
+<u>src/main.zig</u>
+{{< zigdoctest "assets/zig-code/features/25-all-bases.zig" >}}
+
+
+<u>build.zig</u>
+{{< zigdoctest "assets/zig-code/features/26-build.zig" >}}
+
+
+Schauen wir uns das Menü `--help` an:
+```
+$ zig build --help
+Usage: zig build [steps] [options]
+
+Steps:
+  install (default)      Copy build artifacts to prefix path
+  uninstall              Remove build artifacts from prefix path
+  run                    Run the app
+
+General Options:
+  --help                 Print this help and exit
+  --verbose              Print commands before executing them
+  --prefix [path]        Override default install prefix
+  --search-prefix [path] Add a path to look for binaries, libraries, headers
+
+Project-Specific Options:
+  -Dtarget=[string]      The CPU architecture, OS, and ABI to build for.
+  -Drelease-safe=[bool]  optimizations on and safety on
+  -Drelease-fast=[bool]  optimizations on and safety off
+  -Drelease-small=[bool] size optimizations on and safety off
+
+Advanced Options:
+  --build-file [file]         Override path to build.zig
+  --cache-dir [path]          Override path to zig cache directory
+  --override-lib-dir [arg]    Override path to Zig lib directory
+  --verbose-tokenize          Enable compiler debug output for tokenization
+  --verbose-ast               Enable compiler debug output for parsing into an AST
+  --verbose-link              Enable compiler debug output for linking
+  --verbose-ir                Enable compiler debug output for Zig IR
+  --verbose-llvm-ir           Enable compiler debug output for LLVM IR
+  --verbose-cimport           Enable compiler debug output for C imports
+  --verbose-cc                Enable compiler debug output for C compilation
+  --verbose-llvm-cpu-features Enable compiler debug output for LLVM CPU features
+```
+
+Einer der verfügbaren Steps ist es, den Code direkt auszuführen (`run`):
+```
+$ zig build run
+All your base are belong to us.
+```
+
+Hier sind einige Buildscripts als Beispiel:
+
+- [Build script of OpenGL Tetris game](https://github.com/andrewrk/tetris/blob/master/build.zig)
+- [Build script of bare metal Raspberry Pi 3 arcade game](https://github.com/andrewrk/clashos/blob/master/build.zig)
+- [Build script of self-hosted Zig compiler](https://github.com/ziglang/zig/blob/master/build.zig)
+
+## Parallelität mit async-Funktionen
+
+Zig 0.5.0 hat [async-Funktionen eingeführt](https://ziglang.org/download/0.5.0/release-notes.html#Async-Functions). Dieses Feature ist nicht vom Hostsystem oder Heapspeicher abhängig. Das bedeutet, dass async-Funktionen auch auf dem Freestanding-Target verfügbar sind.
+
+Zig leitet automatisch ab, ob eine Funktion async ist, und erlaubt `async`/`await` auf nicht-async-Funktionen, was **Zig-Bibliotheken agnostisch gegenüber blockierendem oder asynchronen I/O** macht. [Zig vermeidet Funktionenfarben](http://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/).
+
+
+
+Die Standardbibliothek implementiert eine Eventschleife, die async-Funktionen über einen Threadpool verteilt und damit N:M-Concurrency erlaubt. An den Bereichen der Multithreading-Sicherheit und Erkennung von Race-Conditions wird aktiv gearbeitet.
+
+## Breite Menge an unterstützten Targets
+
+Zig kommuniziert die Unterstützung von verschiedenen Targets mit "Support Tiers". Beachte, dass die Anforderungen für [Tier 1 Support](#tier-1-support) hoch sind -- [Tier 2 Support](#tier-2-support) ist immer noch ziemlich nützlich.
+
+### Support Table
+
+| | Freestanding | Linux 3.16+ | macOS 10.13+ | Windows 8.1+ | FreeBSD 12.0+ | NetBSD 8.0+ | DragonFly​BSD 5.8+ | UEFI |
+|-|---------------|-------------|--------------|--------------|---------------|-------------|-------------------|------|
+| x86_64 | [Tier 1](#tier-1-support) | [Tier 1](#tier-1-support) | [Tier 1](#tier-1-support) | [Tier 2](#tier-2-support) | [Tier 2](#tier-2-support) | [Tier 2](#tier-2-support) | [Tier 2](#tier-2-support) | [Tier 2](#tier-2-support) |
+| arm64 | [Tier 1](#tier-1-support) | [Tier 2](#tier-2-support) | [Tier 2](#tier-2-support) | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | [Tier 3](#tier-3-support) |
+| arm32 | [Tier 1](#tier-1-support) | [Tier 2](#tier-2-support) | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | [Tier 3](#tier-3-support) |
+| mips32 LE | [Tier 1](#tier-1-support) | [Tier 2](#tier-2-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| i386 | [Tier 1](#tier-1-support) | [Tier 2](#tier-2-support) | [Tier 4](#tier-4-support) | [Tier 2](#tier-2-support) | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | [Tier 2](#tier-2-support) |
+| riscv64 | [Tier 1](#tier-1-support) | [Tier 2](#tier-2-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | [Tier 3](#tier-3-support) |
+| bpf | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| hexagon | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| mips32 BE | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| mips64 | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| amdgcn | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| sparc | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| s390x | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| lanai | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| powerpc32 | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | [Tier 4](#tier-4-support) | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| powerpc64 | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | [Tier 4](#tier-4-support) | N/A | [Tier 3](#tier-3-support) | [Tier 3](#tier-3-support) | N/A | N/A |
+| avr | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| riscv32 | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | [Tier 4](#tier-4-support) |
+| xcore | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| nvptx | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| msp430 | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| r600 | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| arc | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| tce | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| le | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| amdil | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| hsail | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| spir | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| kalimba | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| shave | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+| renderscript | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A | [Tier 4](#tier-4-support) | [Tier 4](#tier-4-support) | N/A | N/A |
+
+
+### WebAssembly Support Table
+
+|        | Freestanding | emscripten | WASI   |
+|--------|---------------|------------|--------|
+| wasm32 | [Tier 1](#tier-1-support)        | [Tier 3](#tier-3-support)     | [Tier 1](#tier-1-support) |
+| wasm64 | [Tier 4](#tier-4-support)        | [Tier 4](#tier-4-support)     | [Tier 4](#tier-4-support) |
+
+
+### Tier-System
+
+#### Tier 1 Support
+- Zig kann für diese Targets nicht nur Maschinencode erzeugen, auch die Cross-Platform-Abstraktionen der Standardbibliothek wurden jeweils vollständig implementiert.
+- Der CI-Server testet diese Targets automatisch bei jedem Commit zum Master-Branch, und aktualisiert die [Downloadseite](https://ziglang.org/de/download) mit Links zu den vorkompilierten Binärdateien.
+- Diese Targets haben vollständige Debuginformations-Fähigkeiten und erzeugen bei fehlgeschlagenen Assertions [Stacktraces](#stacktraces-auf-allen-targets).
+- [die libc ist auch beim Crosskompilieren verfügbar](#zig-enthält-libc).
+- Alle Verhaltenstests und anwendbaren Standardbibliothekstests werden für diese Targets bestanden. Alle Features der Sprache funktionieren korrekt.
+
+#### Tier 2 Support
+- Die Standardbibliothek unterstützt diese Targets, ann aber teilweise "Unsupported OS"-Kompilezeitfehler erzeugen. Um die Lücken in der Standardbibliothek auszufüllen, kann gegen libc oder andere Bibliotheken verlinkt werden.
+- Diese Targets funktionieren, aber werden möglicherweise nicht automatisch getestet, können also gelegentlich rückfällig werden.
+- Einige Tests werden für diese Targets möglicherweise deaktiviert, während wir an [Tier 1 Support](#tier-1-support) arbeiten.
+
+#### Tier 3 Support
+
+- Die Standardbibliothek weiß wenig bis gar nichts von diesen Targets.
+- Weil Zig auf LLVM basiert, kann es momentan für diese Targets kompilieren, und in LLVM sind sie standardmäßig aktiviert.
+- Diese Targets sind nicht standardmäßig getestet; um zu ihnen zu kompilieren, muss man wahrscheinlich zu Zig beitragen.
+- Der Compiler muss möglicherweise aktualisiert werden, mit Informationen zu
+  - Aufrufkonvention der C ABI für das jeweilige Target
+  - Den Größen der Integertypen in C
+  - Bootstrapcode und Standard-Panikhandler
+- `zig targets` enthält diese Targets auf jeden Fall
+
+#### Tier 4 Support
+
+- Unterstützung für diese Targets ist rein experimentell.
+- LLVM enthält dies möglicherweise als experimentelles Target; damit es verfügbar ist, sind Zig-seitige Dateien oder ein speziell konfiguriertes LLVM-Build notwendig. `zig targets` zeigt das Target an, wenn es verfügbar ist.
+- Dieses Target wird möglicherweise von einer offiziellen Seite als veraltet eingestuft, wie zum Beispiel [macosx/i386](https://support.apple.com/en-us/HT208436); in dem Fall wird es Tier 4 nie verlassen.
+- Dieses Target unterstützt möglicherweise nur `--emit asm` und kann keine Objektdateien ausgeben.
+
+## Einfache Unterstützung von Paketen
+
+Der Compiler ist noch nicht vollständig selbst-gehostet, aber es bleiben unter allen Umständen [höchstens drei Schritte](https://github.com/ziglang/zig/issues/853), um von einem System-C++-Compiler aus einen eigenständigen Zig-Compiler für jedes Target zu erreichen. Wie Maya Rashish anmerkt, [lässt sich Zig angenehm und schnell auf andere Plattformen portieren](http://coypu.sdf.org/porting-zig.html).
+
+Nicht-Debug-[Buildmodi](https://ziglang.org/documentation/master/#Build-Mode) sind reproduzierbar/deterministisch.
+
+Es gibt eine [JSON-Version der Downloadseite](https://ziglang.org/de/download/index.json).
+
+Einige Mitglieder des Teams haben Erfahrung im Verwalten von Paketen.
+
+- [Daurnimator](https://github.com/daurnimator) unterstützt ein [Paket für Arch Linux](https://www.archlinux.org/packages/community/x86_64/zig/)
+- [Marc Tiehuis](https://tiehuis.github.io/) unterstützt das Paket für Visual Studio Code.
+- [Andrew Kelley](https://andrewkelley.me/) hat etwa ein Jahr lang [Debian- und Ubuntupakete verwaltet](https://qa.debian.org/developer.php?login=superjoe30%40gmail.com&comaint=yes) und trägt gelegentlich zu [nixpkgs](https://github.com/NixOS/nixpkgs/) bei.
+- [Jeff Fowler](https://blog.jfo.click/) verwaltet das Homebrew-Paket und begann das [Paket für Sublime](https://github.com/ziglang/sublime-zig-language) (jetzt verwaltet von [emekoi](https://github.com/emekoi)).

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -132,11 +132,11 @@ Eine in Zig verfasste Bibliothek kann überall verwendet werden:
 
 Um das zu erreichen, müssen Zig-Programmierer ihren Speicher selbst verwalten und mit scheiternder Speicherallokation umgehen.
 
-Das trifft auch auf die Standardbibliothek zu. Alle Funktionen, die Speicher alloziieren müssen, nehmen einen Allocator als Parameter an. Damit kann die Standardbibliothek sogar auf dem Freestanding-Target verwendet werden.
+Das trifft auch auf die Standardbibliothek zu. Alle Funktionen, die Speicher alloziieren müssen, nehmen einen `Allocator` als Parameter an. Damit kann die Standardbibliothek sogar auf dem Freestanding-Target verwendet werden.
 
 Außer einem [neuen Ansatz zur Fehlerbehandlung](#ein-neuer-ansatz-zur-fehlerbehandlung), stellt Zig [defer](https://ziglang.org/documentation/master/#defer) und [errdefer](https://ziglang.org/documentation/master/#errdefer) zur Verfügung, um alle Ressourcenverwaltung -- nicht nur Speicher -- einfach und leicht verifizierbar zu machen.
 
-Für Beispiele von `defer`, siehe [Integration mit C-Bibliotheken ohne FFI/Bindings](#integration-mit-c-bibliotheken-ohne-ffibindings). Hier ist ein Beispiel von `errdefer`:
+Für Beispiele von `defer` siehe [Integration mit C-Bibliotheken ohne FFI/Bindings](#integration-mit-c-bibliotheken-ohne-ffibindings). Hier ist ein Beispiel von `errdefer`:
 {{< zigdoctest "assets/zig-code/features/11-errdefer.zig" >}}
 
 

--- a/content/learn/samples.de.md
+++ b/content/learn/samples.de.md
@@ -5,7 +5,7 @@ toc: true
 ---
 
 ## Speicherlecks aufdecken
-Der `std.GeneralPurposeAllocator` kann Doppel-Freigabe und Speicherlecks nachverfolgen.
+Der `std.heap.GeneralPurposeAllocator` kann Doppel-Freigabe und Speicherlecks nachverfolgen.
 
 {{< zigdoctest "assets/zig-code/samples/1-memory-leak.zig" >}}
 

--- a/content/learn/samples.de.md
+++ b/content/learn/samples.de.md
@@ -1,0 +1,33 @@
+---
+title: "Codebeispiele"
+mobile_menu_title: "Codebeispiele"
+toc: true
+---
+
+## Speicherlecks aufdecken
+Der `std.GeneralPurposeAllocator` kann Doppel-Freigabe und Speicherlecks nachverfolgen.
+
+{{< zigdoctest "assets/zig-code/samples/1-memory-leak.zig" >}}
+
+
+## Interoperabilität mit C
+Import einer C-Headerdatei und Linken gegen libc und raylib.
+
+{{< zigdoctest "assets/zig-code/samples/2-c-interop.zig" >}}
+
+
+## Zigg Zagg
+Zig ist für Programmierinterviews *optimiert* (nicht wirklich).
+
+{{< zigdoctest "assets/zig-code/samples/3-ziggzagg.zig" >}}
+
+
+## Generische Typen
+In Zig sind Typen Compilezeitwerte; wir benutzen Funktionen, die Typen zurückgeben, um generische Algorithhmen und Datenstrukturen zu implementieren. In diesem Beispiel implementieren wir eine einfache generische Queue und testen ihr Verhalten.
+
+{{< zigdoctest "assets/zig-code/samples/4-generic-type.zig" >}}
+
+
+## cURL mit Zig benutzen
+
+{{< zigdoctest "assets/zig-code/samples/5-curl.zig" >}}

--- a/content/learn/tools.de.md
+++ b/content/learn/tools.de.md
@@ -1,0 +1,33 @@
+---
+title: "Tools"
+menu_title: "Tools"
+mobile_menu_title: "Tools"
+toc: true
+---
+
+## Languageserver
+Languageserver sind editoragnostische Tools für Syntaxhighlighting, Autovervollständigung und viele andere Features. Damit bieten sie häufig eine bessere Entwicklungserfahrung als Editorplugins.
+
+- [zigtools/zls](https://github.com/zigtools/zls)
+
+## Texteditoren
+Editor-spezifische Tools, größtenteils Syntaxhighlighter. 
+
+### VS Code
+- [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
+
+### Sublime Text
+- [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
+
+### Vim
+- [ziglang/zig.vim](https://github.com/ziglang/zig.vim)
+
+### Emacs
+- [ziglang/zig-mode](https://github.com/ziglang/zig-mode)
+
+### Kate
+- [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
+
+## Documentation and Testing
+- [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)
+

--- a/content/learn/why_zig_rust_d_cpp.de.md
+++ b/content/learn/why_zig_rust_d_cpp.de.md
@@ -33,18 +33,18 @@ Beispiele versteckter Allokationen:
 * Das Schlüsselwort `defer` in Go alloziiert Speicher auf einem funktionslokalen Stapel. Abgesehen von dem unintuitiven Kontrollfluss kann ein `defer` innerhalb einer Schleife zu unerwartetem Speicherüberlauf führen.
 * Koroutinen in C++ alloziieren beim Aufruf Heapspeicher.
 * In Go kann ein Funktionsaufruf zu Heapallokation führen, weil Goroutinen kleine Stapel alloziieren, die vergrößert werden müssen, wenn der Aufrufstapel zu tief wird.
-* Rusts Standardbibliotheks-API führt zu einer Panik, wenn kein freier Speicher verfügbar ist, und alternative APIs mit Allocator-Parametern wurden nur nachträglich bedacht (siehe [rust-lang/rust#29802](https://github.com/rust-lang/rust/issues/29802)).
+* Rusts Standardbibliotheks-API führt zu einer Panik, wenn kein freier Speicher verfügbar ist, und alternative APIs mit Allokator-Parametern wurden nur nachträglich bedacht (siehe [rust-lang/rust#29802](https://github.com/rust-lang/rust/issues/29802)).
 
 Fast alle Sprachen mit Garbage Collector sind voller Allokationen, die von der automatischen Spicherverwaltung versteckt werden.
 
 Das Hauptproblem an versteckten Allokationen ist es, dass sie die Wiederverwendbarkeit von Code verhindern, indem sie die Menge an Systemen, die ihn verwenden können, unnötig einschränken. Einfach gesagt gibt es Anwendungsfälle, in denen man sich darauf verlassen können muss, dass Kontrollfluss und Funktionsaufrufe keine Nebeneffekte auf die Speicherallokation haben, und eine Sprache kann diese Anwendunsfälle nur bedienen, wenn sie solche Garantien machen kann.
 
 Zigs Standardbibliothek bietet Features, die Heapallokationen bereitstellen und damit arbeiten, aber diese sind optional, nicht in die Sprache selbst eingebaut.
-Wenn du nie einen Allocator initialisierst, kannst du dir sicher sein, dass dein Programm nichts alloziiert.
+Wenn du nie einen Allokator initialisierst, kannst du dir sicher sein, dass dein Programm nichts alloziiert.
 
 Jedes Feature der Standardbibliothek, das Heapspeicher alloziieren muss, nimmt dazu einen `Allocator` als Parameter an. Das bedeutet, dass Zigs Standardbibliothek Freestanding-Targets unterstützt. Zum Beispiel können `std.ArrayList` und `std.AutoHashMap` für Bare-Metal-Programme genutzt werden!
 
-Eigene Allocators machen manuelle Speicherverwaltung kinderleicht. Zig hat einen Debug-Allocator, der Speichersicherheit bei Use-after-free und Double-free garantiert. Er detektiert und logt automatisch Speicherlecks. Es gibt einen Arena-Allocator, der beliebig viele Allokationen bündeln und zusammen freigeben kann (statt sie einzeln zu verwalten). Besondere Allocators können genutzt werden, um Performance oder Speichernutzung nach den Anforderungen einer Anwendung zu optimieren.
+Eigene Allokatoren machen manuelle Speicherverwaltung kinderleicht. Zig hat einen Debug-Allokator, der Speichersicherheit bei Use-after-free und Double-free garantiert. Er detektiert und logt automatisch Speicherlecks. Es gibt einen Arena-Allokator, der beliebig viele Allokationen bündeln und zusammen freigeben kann (statt sie einzeln zu verwalten). Besondere Allokatoren können genutzt werden, um Performance oder Speichernutzung nach den Anforderungen einer Anwendung zu optimieren.
 
 [1]: Tatsächlich gibt es einen Verkettungsoperator für Strings und Arrays, der aber nur zur Compilezeit benutzbar ist und damit auch keine Laufzeit-Heapallokation mit sich bringt.
 
@@ -66,7 +66,7 @@ Ein heiliger Gral des Programmierens ist Code-Wiederverwendung. Leider scheint e
 
 Zig ist eine Programmiersprache, aber sie bringt auch ein Build-System und einen Paketmanager mit, die auch für traditionelle C/C++-Projekte nützlich sein sollen.
 
-Zig kann nicht nur C- oder C++-Code ersetzen, sondern auch autotools, cmake, make, scons, ninja usw. Und obendrein bietet es (bald™) einen Paketmanager für native Abhängigkeiten. Dieses Build-System soll auch für Projekte relevant sein, deren gesamte Codebasis aus C oder C++ besteht.
+Zig kann nicht nur C- oder C++-Code ersetzen, sondern auch autotools, cmake, make, scons, ninja usw. Und obendrein bietet es (bald™) einen Paketmanager für native Abhängigkeiten. Dieses Build-System ist auch für Projekte relevant, deren gesamte Codebasis aus C oder C++ besteht.
 
 System-Paketmanager wie apt-get, pacman, homebrew und andere sind für Endbenutzer hilfreich, aber sie können für die Bedürfnisse der Entwickler unzureichend sein. Ein sprachspezifischer Paketmanager kann für ein Projekt den Unterschied zwischen keinen und dutzenden Mitwirkenden ausmachen. Bei Open-Source-Projekten ist die Schwierigkeit, das Projekt überhaupt zu kompilieren, eine große Hürde für potentielle Mitwirkende. Für Projekte in C/C++ können Abhängigkeiten fatal sein, besonders auf Windows, wo es keinen Paketmanager gibt. Selbst wenn man nur Zig selbst baut, macht die Abhängigkeit von LLVM den meisten potentiellen Mitwirkenden Schwierigkeiten. Zig bietet (bald) eine Möglichkeit für direkte Abhängigkeiten von nativen Bibliotheken - ohne sich auf den Paketmanager des Benutzers verlassen zu müssen, und auf eine Art und Weise, die erfolgreiche Builds praktisch garantiert, unabhängig vom verwendeten System und der Target-Plattform.
 

--- a/content/learn/why_zig_rust_d_cpp.de.md
+++ b/content/learn/why_zig_rust_d_cpp.de.md
@@ -1,0 +1,90 @@
+---
+title: "Warum Zig, wenn es schon C++, D und Rust gibt?"
+mobile_menu_title: "Warum Zig, wenn..."
+toc: true
+---
+
+
+## Kein verstecketer Kontrollfluss
+
+Wenn Zig-Code nicht aussieht, als ob er in einen Funktionsaufruf springt, dann tut er das nicht. Das bedeutet, dass du sicher sein kannst, dass der folgende Code nur `foo()` und dann `bar()` aufruft, und das ist garantiert, ohne die Typen von irgendwelchen Werten zu kennen:
+
+```zig
+var a = b + c.d;
+foo();
+bar();
+```
+
+Beispiele von verstecktem Kontrollfluss:
+
+* D hat `@property`-Funktionen -- Methoden, deren Aufruf wie ein Feldzugriff aussieht, also könnte im obigen Beispiel `c.d` eine Funktion aufrufen.
+* C++, D, und Rust haben Operatorenüberladung, also könnte der Operator `+` eine Funktion aufrufen.
+* C++, D, und Go haben throw/catch-Ausnahmen, also könnte `foo()` eine Ausahme werfen und die Ausführung von `bar()` verhindern. (Natürlich kann auch in Zig `foo()` in eine Endlosschleife geraten und so die Ausführung von `bar()` verhindern, aber das ist in jeder Turing-vollständigen Sprache möglich.)
+
+Diese Designentscheidung wurde getroffen, um die Lesbarkeit zu verbessern.
+
+## Keine versteckten Speicherallokationen
+
+Zig mischt sich nicht in Heapallokationen ein. Es gibt kein `new`-Schlüsselwort oder andere Sprachfeatures, die Allokationen nutzen (z.B. Verkettungsoperatoren für Strings[1]).
+Das gesamte Konzept des Heaps wird von Bibliotheks- und Anwendungscode verwaltet, nicht von der Sprache.
+
+Beispiele versteckter Allokationen:
+
+* Das Schlüsselwort `defer` in Go alloziiert Speicher auf einem funktionslokalen Stapel. Abgesehen von dem unintuitiven Kontrollfluss kann ein `defer` innerhalb einer Schleife zu unerwartetem Speicherüberlauf führen.
+* Koroutinen in C++ alloziieren beim Aufruf Heapspeicher.
+* In Go kann ein Funktionsaufruf zu Heapallokation führen, weil Goroutinen kleine Stapel alloziieren, die vergrößert werden müssen, wenn der Aufrufstapel zu tief wird.
+* Rusts Standardbibliotheks-API führt zu einer Panik, wenn kein freier Speicher verfügbar ist, und alternative APIs mit Allocator-Parametern wurden nur nachträglich bedacht (siehe [rust-lang/rust#29802](https://github.com/rust-lang/rust/issues/29802)).
+
+Fast alle Sprachen mit Garbage Collector sind voller Allokationen, die von der automatischen Spicherverwaltung versteckt werden.
+
+Das Hauptproblem an versteckten Allokationen ist es, dass sie die Wiederverwendbarkeit von Code verhindern, indem sie die Menge an Systemen, die ihn verwenden können, unnötig einschränken. Einfach gesagt gibt es Anwendungsfälle, in denen man sich darauf verlassen können muss, dass Kontrollfluss und Funktionsaufrufe keine Nebeneffekte auf die Speicherallokation haben, und eine Sprache kann diese Anwendunsfälle nur bedienen, wenn sie solche Garantien machen kann.
+
+Zigs Standardbibliothek bietet Features, die Heapallokationen bereitstellen und damit arbeiten, aber diese sind optional, nicht in die Sprache selbst eingebaut.
+Wenn du nie einen Allocator initialisierst, kannst du dir sicher sein, dass dein Programm nichts alloziiert.
+
+Jedes Feature der Standardbibliothek, das Heapspeicher alloziieren muss, nimmt dazu einen `Allocator` als Parameter an. Das bedeutet, dass Zigs Standardbibliothek Freestanding-Targets unterstützt. Zum Beispiel können `std.ArrayList` und `std.AutoHashMap` für Bare-Metal-Programme genutzt werden!
+
+Eigene Allocators machen manuelle Speicherverwaltung kinderleicht. Zig hat einen Debug-Allocator, der Speichersicherheit bei Use-after-free und Double-free garantiert. Er detektiert und logt automatisch Speicherlecks. Es gibt einen Arena-Allocator, der beliebig viele Allokationen bündeln und zusammen freigeben kann (statt sie einzeln zu verwalten). Besondere Allocators können genutzt werden, um Performance oder Speichernutzung nach den Anforderungen einer Anwendung zu optimieren.
+
+[1]: Tatsächlich gibt es einen Verkettungsoperator für Strings und Arrays, der aber nur zur Compilezeit benutzbar ist und damit auch keine Laufzeit-Heapallokation mit sich bringt.
+
+## Vollständge Unterstützung für keine Standardbibliothek
+
+Wie oben angedeutet, ist Zigs Standardbibliothek absolut optional. Jede API wird nur kompiliert, wenn sie gebraucht wird. Zig unterstützt es gleichermaßen, mit der libc zu linken oder nicht. Zig eignet sich besonders gut für Bare-Metal- und High-Performance-Entwicklung.
+
+Damit hat man das Beste aus beiden Welten: zum Beispiel können WebAssembly-Programme in Zig die normalen Features der Standardbibliothek nutzen, und gleichzeitig im Vergleich zu anderen WebAssembly-Sprachen winzigste Programmdateien erzeugen.
+
+## Eine portable Sprache für Bibliotheken
+
+Ein heiliger Gral des Programmierens ist Code-Wiederverwendung. Leider scheint es in der Praxis, dass wir das Rad immer wieder neu erfinden. Häufig ist das gerechtfertigt.
+
+* Wenn eine Anwendung Echtzeitanforderungen hat, dann ist jede Bibliothek, die Garbage Collection oder ein anderes nicht-deterministisches Verhalten verwendet, als Abhängigkeit disqualifiziert.
+* Wenn eine Sprache es zu einfach macht, Fehler zu ignorieren und zu schwer, zu überprüfen, ob eine Bibliothek Fehler korrekt behandelt und auflöst, kann es verlockend sein, die Bibliothek zu ignorieren und sie neu zu implementieren, um sicherzugehen, dass alle relevanten Fehler korrekt behandelt werden. Zig ist so konzipiert, dass das Faulste, was ein Programmierer tun kann, die korrekte Behandlung von Fehlern ist, und so kann man einigermaßen sicher sein, dass eine Bibliothek Fehler korrekt weitergeben wird.
+* Derzeit ist aus pragmatischer Sicht C die vielseitigste und portabelste Sprache. Jede Sprache, die nicht mit mit C-Code interagieren kann, riskiert es, in Obskurität zu verschwinden. Zig versucht, die neue portable Sprache für Bibliotheken zu werden, indem es gleichzeitig C ABI-Konformität für externe Funktionen vereinfacht und Sicherheit und ein Sprachdesign einführt, das häufige Fehler innerhalb der Implementierungen verhindert.
+
+## Ein Paketmanager und Build-System für bestehende Projekte
+
+Zig ist eine Programmiersprache, aber sie bringt auch ein Build-System und einen Paketmanager mit, die auch für traditionelle C/C++-Projekte nützlich sein sollen.
+
+Zig kann nicht nur C- oder C++-Code ersetzen, sondern auch autotools, cmake, make, scons, ninja usw. Und obendrein bietet es (bald™) einen Paketmanager für native Abhängigkeiten. Dieses Build-System soll auch für Projekte relevant sein, deren gesamte Codebasis aus C oder C++ besteht.
+
+System-Paketmanager wie apt-get, pacman, homebrew und andere sind für Endbenutzer hilfreich, aber sie können für die Bedürfnisse der Entwickler unzureichend sein. Ein sprachspezifischer Paketmanager kann für ein Projekt den Unterschied zwischen keinen und dutzenden Mitwirkenden ausmachen. Bei Open-Source-Projekten ist die Schwierigkeit, das Projekt überhaupt zu kompilieren, eine große Hürde für potentielle Mitwirkende. Für Projekte in C/C++ können Abhängigkeiten fatal sein, besonders auf Windows, wo es keinen Paketmanager gibt. Selbst wenn man nur Zig selbst baut, macht die Abhängigkeit von LLVM den meisten potentiellen Mitwirkenden Schwierigkeiten. Zig bietet (bald) eine Möglichkeit für direkte Abhängigkeiten von nativen Bibliotheken - ohne sich auf den Paketmanager des Benutzers verlassen zu müssen, und auf eine Art und Weise, die erfolgreiche Builds praktisch garantiert, unabhängig vom verwendeten System und der Target-Plattform.
+
+Zig bietet an, das Build-System eines Projekts durch eine vernünftige Sprache zu ersetzen, die eine deklarative API für das Erstellen von Projekten verwendet, die auch eine Paketverwaltung und damit die Möglichkeit bietet, tatsächlich von anderen C-Bibliotheken abzuhängen. Die Fähigkeit, Abhängigkeiten gut zu verwalten, ermöglicht Abstraktionen auf höherer Ebene und damit die Verbreitung von wiederverwendbarem High-Level-Code.
+
+## Einfachheit
+
+C++, Rust und D haben eine große Zahl Features, die von der Bedeutung des Anwendungscodes ablenken können. So muss man früher oder später seine Kenntnis der Programmiersprache debuggen, statt das eigentliche Programm reparieren zu können.
+
+Zig hat keine Makros und keine gesonderte Metaprogrammierung, und ist trotzdem mächtig genug, komplexe Programme einfach und ohne Wiederholungen auszudrücken. Sogar Rust, mit Makros, macht `format!` zu einem Sonderfall und implementiert es im Compiler selbst. Die äquivalente Funktion in Zig ist mit normalem Zig-Code in der Standardbibliothek implementiert.
+
+## Tooling
+
+Zig kann von der [Downloadseite](/download/) heruntergeladen werden. Die binären Archive für Linux, Windows, macOS und FreeBSD...
+
+* werden einfach durch Entpacken des Archivs installiert
+* sind statisch kompiliert
+* benutzen die ausgereifte, gut unterstützte LLVM-Infrastruktur, die weitreichende Optimierungen und Unterstützung für die meisten größeren Plattformen enthält
+* sind mit Quellcode für libc gebündelt, der für jede unterstützte Plattform bei Bedarf automatisch kompiliert wird
+* enthalten ein Buildsystem mit Caching
+* kompilieren C- und C++-Code mit Unterstützung für libc

--- a/content/news/_index.de.md
+++ b/content/news/_index.de.md
@@ -1,0 +1,6 @@
+---
+title: News
+menu_title: "News (ENG)"
+mobile_menu_title: "News (ENG)"
+layout: news-list
+---

--- a/content/translations/index.md
+++ b/content/translations/index.md
@@ -13,3 +13,4 @@ The original content is written in [English](/).
 - [Italiano](../it/)
 - [Português](../pt/)
 - [简体中文](../zh/)
+- [Deutsch](../de/)

--- a/content/zsf/index.de.md
+++ b/content/zsf/index.de.md
@@ -1,0 +1,79 @@
+---
+title: "ZSF unterstützen"
+menu_title: "Die Zig Software Foundation unterstützen"
+mobile_menu_title: "Die ZSF unterstützen"
+date: 2020-10-20T16:29:51+02:00
+---
+{{< sponsor-title-cta "Die Zig Software Foundation unterstützen" >}}
+
+## Auftrag
+Der Auftrag der Zig Software Foundation ist es, die Programmmiersprache Zig zu fördern, zu schützen und zu entwickeln, um das Wachstum einer diversen und internationalen Gemeinschaft von Zig-Programmierern zu ermöglichen und zu unterstützen und Schülern Bildung und Hilfe zu bieten, um die nächste Generation von Programmierern auszubilden, kompetent und ethisch zu handeln und sich an hohen Standards zu messen.
+
+**Die ZSF ist eine amerikanische *501(c)(3) organization*.** Finanzen, Sitzungsprotokolle und andere Details sind [öffentlich verfügbar](https://drive.google.com/drive/folders/1ucHARxVbhrBbuZDbhrGHYDTsYAs8_bMH?usp=sharing).
+
+## Vorstandsmitglieder
+
+- [Andrew Kelley](https://andrewkelley.me/) (Präsident)
+- [Josh Wolfe](https://github.com/thejoshwolfe/) (Sekretär)
+- [Mason Remaley](https://twitter.com/masonremaley/) (Schatzmeister)
+
+## Förderung
+
+Indem du der ZSF spendest, finanzierst du die Entwicklung der Programmiersprache Zig und ihrem Ökosystem, was wiederum der gesamten Open-Source-Community hilft. Mitglieder der Zig-Community haben zu Bugfixes in [LLVM](https://llvm.org/), [Wine](https://winehq.org/), [QEMU](https://qemu.org/), [musl libc](https://musl.libc.org/), [GDB](https://www.gnu.org/software/gdb/) und anderen Projekten beigetragen.
+
+Die ZSF ist eine kleine Organisation, die ihre Mittel effizient nutzt. Der Plan ist es, das zu erhalten, aber wir möchten unbezahle Freiwillige zu bezahlten Unterstützern machen, um Pullrequests zu mergen und das 1.0-Release schneller zu erreichen. Der ganze Sinn der Non-Profit-Organisation ist es, Leuten zugute zu kommen. Wir versuchen, Open-Source-Unterstützer für ihre Zeit zu bezahlen.
+
+Der einfachste Weg, uns zu unterstützen, ist ein Spende über [GitHub Sponsors](https://github.com/sponsors/ziglang).
+
+## Spendeninformationen
+Nützliche Informationen, um auf anderem Wege als durch GitHub Sponsors zu spenden.
+Überprüfe, ob du deine Spende von der Steuer absetzen kannst.
+
+|   **EIN**   | **Adresse** |
+|-------------|-------------|
+| 84-5105214  | Zig Software Foundation  <br> 1732 1st Ave #21385  <br> New York, NY 10128|
+
+### Weitere unterstützte Spendenmethoden
+- Schecks (s. Postadresse oben)
+- Banküberweisungen (auch von außerhalb der US, kontaktiere uns für weitere Informationen)
+- [Benevity](https://benevity.com) (empfohlen, wenn dein Arbeitgeber Spenden ausgleicht!)
+
+**Wende dich mit weiteren Nachfragen gerne an donations@ziglang.org.**
+
+## Unternehmenssponsoren
+
+### Geldspenden
+Die folgenden Unternehmen bieten der Zig Software Foundation direkte finanzielle Unterstützung, indem sie mehr als $1000 monatlich spenden.
+
+{{% sponsor-logos "monetary" %}}
+ <a href="https://pex.com" rel="noopener nofollow" target="_blank"><picture>
+   <picture>
+     <source srcset="../pex-white.svg" media="(prefers-color-scheme: dark)">
+     <img src="../pex-dark.svg">
+   </picture>
+ </a>
+{{% /sponsor-logos %}}
+
+### Infrastruktur
+Die folgenden Unternehmen stellen ihre Dienste der Zig Software Foundation kostenfrei zur Verfügung.
+
+{{% sponsor-logos "services" %}}
+![](../lavatech.png)
+![](../dropbox.png)
+![](../aws.png)
+{{% /sponsor-logos %}}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/content/zsf/index.de.md
+++ b/content/zsf/index.de.md
@@ -48,8 +48,8 @@ Die folgenden Unternehmen bieten der Zig Software Foundation direkte finanzielle
 {{% sponsor-logos "monetary" %}}
  <a href="https://pex.com" rel="noopener nofollow" target="_blank"><picture>
    <picture>
-     <source srcset="../pex-white.svg" media="(prefers-color-scheme: dark)">
-     <img src="../pex-dark.svg">
+     <source srcset="/pex-white.svg" media="(prefers-color-scheme: dark)">
+     <img src="/pex-dark.svg">
    </picture>
  </a>
 {{% /sponsor-logos %}}
@@ -58,11 +58,10 @@ Die folgenden Unternehmen bieten der Zig Software Foundation direkte finanzielle
 Die folgenden Unternehmen stellen ihre Dienste der Zig Software Foundation kostenfrei zur Verfügung.
 
 {{% sponsor-logos "services" %}}
-![](../lavatech.png)
-![](../dropbox.png)
-![](../aws.png)
+![](/lavatech.png)
+![](/dropbox.png)
+![](/aws.png)
 {{% /sponsor-logos %}}
-
 
 
 

--- a/themes/ziglang-original/i18n/de.toml
+++ b/themes/ziglang-original/i18n/de.toml
@@ -1,0 +1,50 @@
+[slogan-latest-release]
+other = "Letztes Release: &nbsp; <b>{{ . }}</b>"
+
+
+[back-to-home]
+other = "← Zurück zur <b>Startseite</b>"
+
+[back-to-parent]
+other = "← Zurück zum Abschnitt <b>{{ . }}</b>"
+
+
+[menu-community]
+other = "Tritt einer Community bei"
+
+[menu-source]
+other = "Quellcode"
+
+
+[downloads-heading]
+other = "Releases"
+
+[downloads-install-from-pkg-manager]
+other = "Du kannst Zig auch <a href=\"https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager\"> mit einem Paketmanager installieren</a>."
+
+[downloads-json]
+other = "Diese Seite ist auch als <a href=\"https://ziglang.org/download/index.json\">JSON-Version</a> verfügbar."
+
+[download-binary]
+other = "Binärdatei"
+
+[download-documentation]
+other = "<a href=\"{{ . }}\">Dokumentation</a>"
+
+[download-filename]
+other = "Dateiname"
+
+[download-kind]
+other = "Art"
+
+[download-release-notes]
+other = "<a href=\"{{ . }}\">Release Notes</a>"
+
+[download-size]
+other = "Größe"
+
+[download-source]
+other = "Quellcode"
+
+[download-stdlib-docs]
+other = "<a href=\"{{ . }}\">Dokumentation der Standardbibliothek</a> (experimentell)"


### PR DESCRIPTION
Translated the pages Index, Learn, Getting Started, Overview, Samples, Tools, Why Zig, and ZSF.

Some of the translations may be a bit too literal, but hopefully not grammatically wrong; this took a bit longer than I expected, and I couldn't be bothered to rephrase every sentence into the most elegant prose.

The reader is addressed in the informal form, which I found most fitting for an open-source project talking to its community, but one might also argue that the formal pronouns are more appropriate for an organization addressing potential sponsors. I would like to hear another German speaker's opinion on this.

I have converted most section references from absolute to relative links (`[...](https://ziglang.org/#Stack-traces-on-all-targets)` -> `[...](#stacktraces-auf-allen-targets)`), but may have overlooked one or two.