### PR TITLE
Fix typos in the German translations

### DIFF
--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -17,7 +17,7 @@ Debugge deine Anwendung, nicht deine Kenntnis der Sprache.
 - Kein Präprozessor, keine Makros. 
 
 # ⚡ Comptime
-Eine moderner Ansatz zur Metaprogrammierung -- basierend auf Compile-Zeit-Ausführung and Lazy Evaluation.
+Eine moderner Ansatz zur Metaprogrammierung -- basierend auf Compile-Zeit-Ausführung und Lazy Evaluation.
 
 - Rufe jede Funktion zur Compile-Zeit auf.
 - Manipuliere Typen als Werte, ohne Laufzeit-Overhead.
@@ -62,7 +62,7 @@ Schreibe schnellen und klaren Code, der mit allen Fehlerbedingungen umgehen kann
 {{% div class="community-message" %}}
 # Die Zig-Community ist dezentralisiert
 Jeder darf einen Raum für die Community schaffen.
-Es gibt kein "offiziell" or "inoffiziell", aber jeder Versammlungsort hat seine eigenen Regeln und Moderatoren.
+Es gibt kein "offiziell" oder "inoffiziell", aber jeder Versammlungsort hat seine eigenen Regeln und Moderatoren.
 
 <div style="">
 <h1>
@@ -90,7 +90,7 @@ Mitwirkende müssen sich an Zigs [Code of Conduct](https://github.com/ziglang/zi
 {{% div class="container" style="display:flex;flex-direction:column;justify-content:center;text-align:center; padding: 20px 0;" title="Zig Software Foundation" %}}
 ## Die ZSF ist eine 501(c)(3) Non-Profit-Organisation.
 
-Die Zig Software Foundation ist eine Non-Profit-Organisation, die 2020 von Andrew Kelley, dem Schöpfer von Zig, geründet wurde, um die Entwicklung der Sprache zu unterstützen. Momentan bietet die ZSF einigen Kernmitwirkenden konkurrenzfähig bezahlte Arbeit. Wir hoffen, dies künftig witeren Mitwirkenden anbieten zu können.
+Die Zig Software Foundation ist eine Non-Profit-Organisation, die 2020 von Andrew Kelley, dem Schöpfer von Zig, gegründet wurde, um die Entwicklung der Sprache zu unterstützen. Momentan bietet die ZSF einigen Kernmitwirkenden konkurrenzfähig bezahlte Arbeit. Wir hoffen, dies künftig weiteren Mitwirkenden anbieten zu können.
 
 Die Zig Software Foundation wird von Spenden erhalten.
 
@@ -114,7 +114,7 @@ Die folgenden Unternehmen bieten der Zig Software Foundation direkte finanzielle
  </a>
 {{% /sponsor-logos %}}
 
-# GitHub Sponsoren
+# GitHub-Sponsoren
 Dank vieler Unterstützer ist das Projekt der Open-Source-Community und nicht Aktionären Rechenschaft schuldig. Insbesondere [unterstützen](zsf/) diese guten Leute Zig mit monatlich $200 oder mehr:
 
 - [Karrick McDermott](https://github.com/karrick)

--- a/content/learn/_index.de.md
+++ b/content/learn/_index.de.md
@@ -16,7 +16,7 @@ Dieser Abschnitt enthält Ressourcen, die hoffentlich helfen, Zigs Philosophie z
 Einige Seiten zum Einstieg in Zig für Programmierer mit verschiedenen Vorkenntnissen:
 
 - [Ausführliche Übersicht](overview/)  
-Eine ausführliche Übersicht über Zigs Features aus der Perspektive des Systemprogrammierens.
+Eine ausführliche Übersicht über Zigs Features aus der Perspektive des Systemprogrammierers.
 - [Warum Zig, wenn es schon C++, D und Rust gibt?](why_zig_rust_d_cpp/)  
 Eine Einführung für C++-, D-, und Rust-Programmierer.
 - [Codebeispiele](samples/)  
@@ -26,7 +26,7 @@ Eine Liste von Werkzeugen, die beim Schreiben von Zig unterstützen.
 
 
 ## Einstieg
-Wenn du bereit bist, in Zig zu programmmieren, hilft diese Anleitung bei der Einrichtung des Systems.
+Wenn du bereit bist, in Zig zu programmieren, hilft diese Anleitung bei der Einrichtung des Systems.
 
 - [Einstieg]({{< ref "getting-started.md" >}})  
 
@@ -34,9 +34,9 @@ Wenn du bereit bist, in Zig zu programmmieren, hilft diese Anleitung bei der Ein
 - [Zig Learn](https://ziglearn.org)  
 Eine strukturierte Einführung in Zig von [Sobeston](https://github.com/sobeston).
 
-## Relevante Videos and Blogposts
+## Relevante Videos und Blogposts
 - [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  
-Video von [Andrew Kelley](https://andrewkelley.me), das Zig and seine Philosophie vorstellt.
+Video von [Andrew Kelley](https://andrewkelley.me), das Zig und seine Philosophie vorstellt.
 - [Zig's New Relationship with LLVM](https://kristoff.it/blog/zig-new-relationship-llvm/)  
 Ein Blogpost über den Weg zu einem selbst-hostenden Zig-Compiler, auch vorgestellt in einem [Artikel auf lwn.net](https://lwn.net/Articles/833400/).
 

--- a/content/learn/getting-started.de.md
+++ b/content/learn/getting-started.de.md
@@ -6,7 +6,7 @@ toc: true
 
 {{% div class="box thin"%}}
 **<center>Hinweis für Nutzer von Apple Silicon</center>**
-Zigs Unterstützung für Code Signing ist experimentell. Du kannst Zig mit deinem M1 Mac vewenden,
+Zigs Unterstützung für Code Signing ist experimentell. Du kannst Zig mit deinem M1 Mac verwenden,
 aber momentan ist der einzige Weg, Zig für arm64 macOS zu bekommen, es selbst zu kompilieren.
 Beachte dazu den Abschnitt [Zig selbst kompilieren](#zig-selbst-kompilieren).
 {{% /div %}}
@@ -28,7 +28,7 @@ Dies ist der einfachste Weg, Zig zu bekommen: nimm ein Paket von der [Downloads]
 extrahiere es in ein Verzeichnis und füge es an deinen `PATH` an, um Zig von überall nutzen zu können.
 
 #### Auf Windows den PATH ändern
-Um deine PATH-Variable auf Windows einzustellen, führe **einen** der folgenden Codschnipsel mit Powershell aus.
+Um deine PATH-Variable auf Windows einzustellen, führe **einen** der folgenden Codeschnipsel mit Powershell aus.
 Entscheide dich, ob du diese Änderung systemweit durchführen willst (erfordert eine mit Adminrechten ausgeführte Powershell)
 oder nur für deinen Benutzer, und **ändere den Schnipsel, um auf deine Kopie von Zig zu verweisen**.
 Das `;` vor dem `C:` ist kein Tippfehler.
@@ -110,7 +110,7 @@ Wenn du die Installation erfolgreich abgeschlossen hast, solltest du Zig aus der
 
 Probieren wir das mit deinem ersten Zig-Programm aus!
 
-Wechlse in dein Projektverzeichnis und führe aus:
+Wechsle in dein Projektverzeichnis und führe aus:
 ```bash
 mkdir hello-world
 cd hello-world
@@ -131,7 +131,7 @@ info: All your codebase are belong to us.
 ausgibt. Glückwunsch, du hast jetzt eine funktionierende Installation von Zig!
 
 ## Nächste Schritte
-**Sieh dir auch auch die anderen Ressourcen im Abschnitt [Lernen](../) an**, suche dir die Dokumentation für deine Version (Hinweis: Nightly Builds sollten die `master`-Dokumenatation benutzen) und lies vielleicht [ziglearn.org](https://ziglearn.org).
+**Sieh dir auch auch die anderen Ressourcen im Abschnitt [Lernen](../) an**, suche dir die Dokumentation für deine Version (Hinweis: Nightly Builds sollten die `master`-Dokumentation benutzen) und lies vielleicht [ziglearn.org](https://ziglearn.org).
 
 Zig ist ein junges Projekt, und wir haben leider nicht die Kapazitäten, umfangreiche Dokumentation und Lernmaterialien zu erzeugen. Wenn du feststeckst, kannst du aber auch [einer Zig-Community beitreten](https://github.com/ziglang/zig/wiki/Community), oder Initiativen wie [Zig SHOWTIME](https://zig.show) ansehen.
 

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -9,7 +9,7 @@ Debugge deine Anwendung, nicht deine Kenntnis der Programmiersprache.
 
 Zig's gesamte Syntax ist in 500 Zeilen [PEG-Grammatik](https://ziglang.org/documentation/master/#Grammar) beschrieben.
 
-Es gibt **keinen verstecketen Kontrollfluss**, keine versteckten Speicherallokationen, keinen Präprozessor, und keine Makros. Wenn Zig kode nicht aussieht, als ober in einen Funktionsaufruf springt, dann tut er das nicht. Das bedeutet, dass du sicher sein kannst, dass der folgende Code nur `foo()` und dann `bar()` aufruft, und das ist garantiert, ohne die Typen von irgendwelchen Werten zu kennen:
+Es gibt **keinen versteckten Kontrollfluss**, keine versteckten Speicherallokationen, keinen Präprozessor, und keine Makros. Wenn Zig Code nicht aussieht, als ober in einen Funktionsaufruf springt, dann tut er das nicht. Das bedeutet, dass du sicher sein kannst, dass der folgende Code nur `foo()` und dann `bar()` aufruft, und das ist garantiert, ohne die Typen von irgendwelchen Werten zu kennen:
 
 ```zig
 var a = b + c.d;
@@ -17,11 +17,11 @@ foo();
 bar();
 ```
 
-Beispiele von verstecketem Kontrollfluss:
+Beispiele von verstecktem Kontrollfluss:
 
 - D hat `@property`-Funktionen -- Methoden, deren Aufruf wie ein Feldzugriff aussieht, also könnte im obigen Beispiel `c.d` eine Funktion aufrufen.
 - C++, D, und Rust haben Operatorenüberladung, also könnte der Operator `+` eine Funktion aufrufen.
-- C++, D, und Go haben throw/catch-Ausnahmen, also könnte `foo()` eine Ausahme werfen und die Ausführung von `bar()` verhindern.
+- C++, D, und Go haben throw/catch-Ausnahmen, also könnte `foo()` eine Ausnahme werfen und die Ausführung von `bar()` verhindern.
 
  Zig fördert Codewartung und Lesbarkeit, indem Kontrollfluss ausschließlich mit Schlüsselwörtern und Funktionsaufrufen geschieht.
 
@@ -38,18 +38,18 @@ So sieht [Integer Overflow](https://ziglang.org/documentation/master/#Integer-Ov
 
 {{< zigdoctest "assets/zig-code/features/1-integer-overflow.zig" >}}
 
-So sieht er zur Laufzeit aus, in safety-checked builds:
+So sieht er zur Laufzeit aus, in safety-checked-Builds:
 
 {{< zigdoctest "assets/zig-code/features/2-integer-overflow-runtime.zig" >}}
 
 
 Die [Stacktraces funktionieren auf allen Targets](#stacktraces-auf-allen-targets), auch [freestanding](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html).
 
-Zig erlaubt es, sich auf einen Buildmodus mit aktivierter Sicherheit verlassen, und die Sicherheit an performance-bottlenecks selektiv zu deaktivieren. Das vorherige Beispiel könnte so verändert werden:
+Zig erlaubt es, sich auf einen Buildmodus mit aktivierter Sicherheit zu verlassen, und die Sicherheit an Performanceengpässen selektiv zu deaktivieren. Das vorherige Beispiel könnte so verändert werden:
 
 {{< zigdoctest "assets/zig-code/features/3-undefined-behavior.zig" >}}
 
-Zig benutzt [undefniniertes Verhalten](https://ziglang.org/documentation/master/#Undefined-Behavior) als ein  messerscharfes Instrument zur Vermeidung von Bugs und Performanceverbesserung.
+Zig benutzt [undefiniertes Verhalten](https://ziglang.org/documentation/master/#Undefined-Behavior) als ein  messerscharfes Instrument zur Vermeidung von Bugs und Performanceverbesserung.
 
 Apropos Performance: Zig ist schneller als C.
 
@@ -66,7 +66,7 @@ Beachte bitte, dass Zig keine vollständig sichere Sprache ist. Interessierte an
 
 ## Zig ist nicht abhängig von C, sondern konkurriert mit C
 
-Zigs Standarsbibliothek kann libc einbeziehen, aber ist nicht darauf angewiesen. Hier ist Hello World:
+Zigs Standardbibliothek kann libc einbeziehen, aber ist nicht darauf angewiesen. Hier ist Hello World:
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
@@ -122,9 +122,9 @@ Dieselbe Syntax funktioniert mit [while](https://ziglang.org/documentation/maste
 
 Eine in Zig verfasste Bibliothek kann überall verwendet werden:
 
-- [Desktopanwendungen](https://github.com/TM35-Metronome/) & [games](https://github.com/dbandstra/oxid)
+- [Desktopanwendungen](https://github.com/TM35-Metronome/) & [Spiele](https://github.com/dbandstra/oxid)
 - Server mit geringer Latenz
-- [etriebssystemkernel](https://github.com/AndreaOrru/zen)
+- [Betriebssystemkernel](https://github.com/AndreaOrru/zen)
 - [Embedded-Geräte](https://github.com/skyfex/zig-nrf-demo/)
 - Echtzeitsoftware, z.B. Liveauftritte, Flugzeuge, Herzschrittmacher
 - [In Webbrowsern oder anderen Plugins mit WebAssembly](https://shritesh.github.io/zigfmt-web/)
@@ -132,7 +132,7 @@ Eine in Zig verfasste Bibliothek kann überall verwendet werden:
 
 Um das zu erreichen, müssen Zig-Programmierer ihren Speicher selbst verwalten und mit scheiternder Speicherallokation umgehen.
 
-Das trifft auch auf die Standardbibliothek zu. Alle Funktionen, die Speicher alloziieren müssen, nehmen einen `Allocator` als Parameter an. Damit kann die Standardbibliothek sogar auf dem Freestanding-Target verwendet werden.
+Das trifft auch auf die Standardbibliothek zu. Alle Funktionen, die Speicher allozieren müssen, nehmen einen `Allocator` als Parameter an. Damit kann die Standardbibliothek sogar auf dem Freestanding-Target verwendet werden.
 
 Außer einem [neuen Ansatz zur Fehlerbehandlung](#ein-neuer-ansatz-zur-fehlerbehandlung), stellt Zig [defer](https://ziglang.org/documentation/master/#defer) und [errdefer](https://ziglang.org/documentation/master/#errdefer) zur Verfügung, um alle Ressourcenverwaltung -- nicht nur Speicher -- einfach und leicht verifizierbar zu machen.
 
@@ -214,7 +214,7 @@ Output device: Built-in Audio Analog Stereo
 ^C
 ```
 
-[Dieser Zigcode ist signifikant einfacher als der äquivalente C-Code](https://gist.github.com/andrewrk/d285c8f912169329e5e28c3d0a63c1d8), hat mehr Sicherheitsvorkehrungen, und all das wird mit einem einfache `@cImport` der C-Headerdateien erreicht -- ohne API-Bindings.
+[Dieser Zig-Code ist signifikant einfacher als der äquivalente C-Code](https://gist.github.com/andrewrk/d285c8f912169329e5e28c3d0a63c1d8), hat mehr Sicherheitsvorkehrungen, und all das wird mit einem einfache `@cImport` der C-Headerdateien erreicht -- ohne API-Bindings.
 
 *Zig kann C-Bibliotheken besser nutzen als das C selbst kann.*
 
@@ -400,14 +400,14 @@ $ ldd hello
 
 In diesem Beispiel hat Zig musls Quellcode kompiliert und verlinkt. Dank dem [Cachesystem](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching) bleibt das Build von musl-libc für `x86_64-linux` verfügbar und kann bei Bedarf sofort genutzt werden.
 
-Das bedeutet, dass die Funktionalität auf jeder Plattform verfügbar ist. Nutzer von Windows und macOS können Zig- und C-Code für jedes der obigen Targets kompilieren und gegen libc linken. Auf ähnliche Art und Weise kann Code für andere Priozessorarchitekturen crosskompiliert werden:
+Das bedeutet, dass die Funktionalität auf jeder Plattform verfügbar ist. Nutzer von Windows und macOS können Zig- und C-Code für jedes der obigen Targets kompilieren und gegen libc linken. Auf ähnliche Art und Weise kann Code für andere Prozessorarchitekturen crosskompiliert werden:
 ```
 $ zig build-exe --c-source hello.c --library c -target aarch64v8-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
 
-In macher Hinsicht kann Zig besser C kompilieren als C-Compiler!
+In mancher Hinsicht kann Zig besser C kompilieren als C-Compiler!
 
 Diese Funktionalität ist mehr als eine mit Zig gebündelte Cross-Toolchain. Zum Beispiel sind die libc-Header, die Zig mitbringt, unkomprimiert 22 MiB groß. Dabei kommen die Header für musl libc + Linux auf x86_64 alleine auf 8 MiB, und die Header für glibc machen 3.1 MiB aus (glibc fehlen die Linux-Header), aber Zig enthält momentan 40 libcs. Ohne Bündelung wären das 444 MiB. Dank meines Tools [process_headers](https://github.com/ziglang/zig/blob/0.4.0/libc/process_headers.zig) jedoch, und ein wenig [guter alter manueller Arbeit](https://github.com/ziglang/zig/wiki/Updating-libc), bleiben Zigs binäre Tarballs bei insgesamt rund 30 MiB, trotz Unterstützung für libc auf all diesen  Targets, sowie compiler-rt, libunwind und libcxx, und dem Clang-kompatiblen C-Compiler. Zum Vergleich: das Build von clang 8.0.0 von llvm.org für Windows ist 132 MiB groß.
 
@@ -544,14 +544,14 @@ Zig kommuniziert die Unterstützung von verschiedenen Targets mit "Support Tiers
 ### Tier-System
 
 #### Tier 1 Support
-- Zig kann für diese Targets nicht nur Maschinencode erzeugen, auch die Cross-Platform-Abstraktionen der Standardbibliothek wurden jeweils vollständig implementiert.
+- Zig kann für diese Targets nicht nur Maschinencode erzeugen, auch die plattformunabhängigen Abstraktionen der Standardbibliothek wurden jeweils vollständig implementiert.
 - Der CI-Server testet diese Targets automatisch bei jedem Commit zum Master-Branch, und aktualisiert die [Downloadseite]({{< ref "/download/" >}}) mit Links zu den vorkompilierten Binärdateien.
 - Diese Targets haben vollständige Debuginformations-Fähigkeiten und erzeugen bei fehlgeschlagenen Assertions [Stacktraces](#stacktraces-auf-allen-targets).
 - [die libc ist auch beim Crosskompilieren verfügbar](#zig-enthält-libc).
 - Alle Verhaltenstests und anwendbaren Standardbibliothekstests werden für diese Targets bestanden. Alle Features der Sprache funktionieren korrekt.
 
 #### Tier 2 Support
-- Die Standardbibliothek unterstützt diese Targets, ann aber teilweise "Unsupported OS"-Kompilezeitfehler erzeugen. Um die Lücken in der Standardbibliothek auszufüllen, kann gegen libc oder andere Bibliotheken verlinkt werden.
+- Die Standardbibliothek unterstützt diese Targets, kann aber teilweise "Unsupported OS"-Kompilezeitfehler erzeugen. Um die Lücken in der Standardbibliothek auszufüllen, kann gegen libc oder andere Bibliotheken verlinkt werden.
 - Diese Targets funktionieren, aber werden möglicherweise nicht automatisch getestet, können also gelegentlich rückfällig werden.
 - Einige Tests werden für diese Targets möglicherweise deaktiviert, während wir an [Tier 1 Support](#tier-1-support) arbeiten.
 

--- a/content/learn/samples.de.md
+++ b/content/learn/samples.de.md
@@ -23,7 +23,7 @@ Zig ist für Programmierinterviews *optimiert* (nicht wirklich).
 
 
 ## Generische Typen
-In Zig sind Typen Compilezeitwerte; wir benutzen Funktionen, die Typen zurückgeben, um generische Algorithhmen und Datenstrukturen zu implementieren. In diesem Beispiel implementieren wir eine einfache generische Queue und testen ihr Verhalten.
+In Zig sind Typen Compilezeitwerte; wir benutzen Funktionen, die Typen zurückgeben, um generische Algorithmen und Datenstrukturen zu implementieren. In diesem Beispiel implementieren wir eine einfache generische Queue und testen ihr Verhalten.
 
 {{< zigdoctest "assets/zig-code/samples/4-generic-type.zig" >}}
 

--- a/content/learn/tools.de.md
+++ b/content/learn/tools.de.md
@@ -5,8 +5,8 @@ mobile_menu_title: "Tools"
 toc: true
 ---
 
-## Languageserver
-Languageserver sind editoragnostische Tools für Syntaxhighlighting, Autovervollständigung und viele andere Features. Damit bieten sie häufig eine bessere Entwicklungserfahrung als Editorplugins.
+## Language Server
+Language Server sind editor-agnostische Tools für Syntaxhighlighting, Autovervollständigung und viele andere Features. Damit bieten sie häufig eine bessere Entwicklungserfahrung als Editorplugins.
 
 - [zigtools/zls](https://github.com/zigtools/zls)
 
@@ -28,6 +28,6 @@ Editor-spezifische Tools, größtenteils Syntaxhighlighter.
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-## Documentation and Testing
+## Dokumentation und Tests
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)
 

--- a/content/learn/why_zig_rust_d_cpp.de.md
+++ b/content/learn/why_zig_rust_d_cpp.de.md
@@ -5,7 +5,7 @@ toc: true
 ---
 
 
-## Kein verstecketer Kontrollfluss
+## Kein versteckter Kontrollfluss
 
 Wenn Zig-Code nicht aussieht, als ob er in einen Funktionsaufruf springt, dann tut er das nicht. Das bedeutet, dass du sicher sein kannst, dass der folgende Code nur `foo()` und dann `bar()` aufruft, und das ist garantiert, ohne die Typen von irgendwelchen Werten zu kennen:
 
@@ -19,7 +19,7 @@ Beispiele von verstecktem Kontrollfluss:
 
 * D hat `@property`-Funktionen -- Methoden, deren Aufruf wie ein Feldzugriff aussieht, also könnte im obigen Beispiel `c.d` eine Funktion aufrufen.
 * C++, D, und Rust haben Operatorenüberladung, also könnte der Operator `+` eine Funktion aufrufen.
-* C++, D, und Go haben throw/catch-Ausnahmen, also könnte `foo()` eine Ausahme werfen und die Ausführung von `bar()` verhindern. (Natürlich kann auch in Zig `foo()` in eine Endlosschleife geraten und so die Ausführung von `bar()` verhindern, aber das ist in jeder Turing-vollständigen Sprache möglich.)
+* C++, D, und Go haben throw/catch-Ausnahmen, also könnte `foo()` eine Ausnahme werfen und die Ausführung von `bar()` verhindern. (Natürlich kann auch in Zig `foo()` in eine Endlosschleife geraten und so die Ausführung von `bar()` verhindern, aber das ist in jeder Turing-vollständigen Sprache möglich.)
 
 Diese Designentscheidung wurde getroffen, um die Lesbarkeit zu verbessern.
 
@@ -30,25 +30,25 @@ Das gesamte Konzept des Heaps wird von Bibliotheks- und Anwendungscode verwaltet
 
 Beispiele versteckter Allokationen:
 
-* Das Schlüsselwort `defer` in Go alloziiert Speicher auf einem funktionslokalen Stapel. Abgesehen von dem unintuitiven Kontrollfluss kann ein `defer` innerhalb einer Schleife zu unerwartetem Speicherüberlauf führen.
-* Koroutinen in C++ alloziieren beim Aufruf Heapspeicher.
-* In Go kann ein Funktionsaufruf zu Heapallokation führen, weil Goroutinen kleine Stapel alloziieren, die vergrößert werden müssen, wenn der Aufrufstapel zu tief wird.
+* Das Schlüsselwort `defer` in Go alloziert Speicher auf einem funktionslokalen Stapel. Abgesehen von dem unintuitiven Kontrollfluss kann ein `defer` innerhalb einer Schleife zu unerwartetem Speicherüberlauf führen.
+* Koroutinen in C++ allozieren beim Aufruf Heapspeicher.
+* In Go kann ein Funktionsaufruf zu Heapallokationen führen, weil Goroutinen kleine Stapel allozieren, die vergrößert werden müssen, wenn der Aufrufstapel zu tief wird.
 * Rusts Standardbibliotheks-API führt zu einer Panik, wenn kein freier Speicher verfügbar ist, und alternative APIs mit Allokator-Parametern wurden nur nachträglich bedacht (siehe [rust-lang/rust#29802](https://github.com/rust-lang/rust/issues/29802)).
 
-Fast alle Sprachen mit Garbage Collector sind voller Allokationen, die von der automatischen Spicherverwaltung versteckt werden.
+Fast alle Sprachen mit Garbage Collector sind voller Allokationen, die von der automatischen Speicherverwaltung versteckt werden.
 
-Das Hauptproblem an versteckten Allokationen ist es, dass sie die Wiederverwendbarkeit von Code verhindern, indem sie die Menge an Systemen, die ihn verwenden können, unnötig einschränken. Einfach gesagt gibt es Anwendungsfälle, in denen man sich darauf verlassen können muss, dass Kontrollfluss und Funktionsaufrufe keine Nebeneffekte auf die Speicherallokation haben, und eine Sprache kann diese Anwendunsfälle nur bedienen, wenn sie solche Garantien machen kann.
+Das Hauptproblem an versteckten Allokationen ist es, dass sie die Wiederverwendbarkeit von Code verhindern, indem sie die Menge an Systemen, die ihn verwenden können, unnötig einschränken. Einfach gesagt gibt es Anwendungsfälle, in denen man sich darauf verlassen können muss, dass Kontrollfluss und Funktionsaufrufe keine Nebeneffekte auf die Speicherallokation haben, und eine Sprache kann diese Anwendungsfälle nur bedienen, wenn sie solche Garantien machen kann.
 
 Zigs Standardbibliothek bietet Features, die Heapallokationen bereitstellen und damit arbeiten, aber diese sind optional, nicht in die Sprache selbst eingebaut.
-Wenn du nie einen Allokator initialisierst, kannst du dir sicher sein, dass dein Programm nichts alloziiert.
+Wenn du nie einen Allokator initialisierst, kannst du dir sicher sein, dass dein Programm nichts alloziert.
 
-Jedes Feature der Standardbibliothek, das Heapspeicher alloziieren muss, nimmt dazu einen `Allocator` als Parameter an. Das bedeutet, dass Zigs Standardbibliothek Freestanding-Targets unterstützt. Zum Beispiel können `std.ArrayList` und `std.AutoHashMap` für Bare-Metal-Programme genutzt werden!
+Jedes Feature der Standardbibliothek, das Heapspeicher allozieren muss, nimmt dazu einen `Allocator` als Parameter an. Das bedeutet, dass Zigs Standardbibliothek Freestanding-Targets unterstützt. Zum Beispiel können `std.ArrayList` und `std.AutoHashMap` für Bare-Metal-Programme genutzt werden!
 
 Eigene Allokatoren machen manuelle Speicherverwaltung kinderleicht. Zig hat einen Debug-Allokator, der Speichersicherheit bei Use-after-free und Double-free garantiert. Er detektiert und logt automatisch Speicherlecks. Es gibt einen Arena-Allokator, der beliebig viele Allokationen bündeln und zusammen freigeben kann (statt sie einzeln zu verwalten). Besondere Allokatoren können genutzt werden, um Performance oder Speichernutzung nach den Anforderungen einer Anwendung zu optimieren.
 
 [1]: Tatsächlich gibt es einen Verkettungsoperator für Strings und Arrays, der aber nur zur Compilezeit benutzbar ist und damit auch keine Laufzeit-Heapallokation mit sich bringt.
 
-## Vollständge Unterstützung für keine Standardbibliothek
+## Vollständige Unterstützung für keine Standardbibliothek
 
 Wie oben angedeutet, ist Zigs Standardbibliothek absolut optional. Jede API wird nur kompiliert, wenn sie gebraucht wird. Zig unterstützt es gleichermaßen, mit der libc zu linken oder nicht. Zig eignet sich besonders gut für Bare-Metal- und High-Performance-Entwicklung.
 
@@ -60,7 +60,7 @@ Ein heiliger Gral des Programmierens ist Code-Wiederverwendung. Leider scheint e
 
 * Wenn eine Anwendung Echtzeitanforderungen hat, dann ist jede Bibliothek, die Garbage Collection oder ein anderes nicht-deterministisches Verhalten verwendet, als Abhängigkeit disqualifiziert.
 * Wenn eine Sprache es zu einfach macht, Fehler zu ignorieren und zu schwer, zu überprüfen, ob eine Bibliothek Fehler korrekt behandelt und auflöst, kann es verlockend sein, die Bibliothek zu ignorieren und sie neu zu implementieren, um sicherzugehen, dass alle relevanten Fehler korrekt behandelt werden. Zig ist so konzipiert, dass das Faulste, was ein Programmierer tun kann, die korrekte Behandlung von Fehlern ist, und so kann man einigermaßen sicher sein, dass eine Bibliothek Fehler korrekt weitergeben wird.
-* Derzeit ist aus pragmatischer Sicht C die vielseitigste und portabelste Sprache. Jede Sprache, die nicht mit mit C-Code interagieren kann, riskiert es, in Obskurität zu verschwinden. Zig versucht, die neue portable Sprache für Bibliotheken zu werden, indem es gleichzeitig C ABI-Konformität für externe Funktionen vereinfacht und Sicherheit und ein Sprachdesign einführt, das häufige Fehler innerhalb der Implementierungen verhindert.
+* Derzeit ist aus pragmatischer Sicht C die vielseitigste und portabelste Sprache. Jede Sprache, die nicht mit mit C-Code interagieren kann, riskiert es, in der Versenkung zu verschwinden. Zig versucht, die neue portable Sprache für Bibliotheken zu werden, indem es gleichzeitig C ABI-Konformität für externe Funktionen vereinfacht und Sicherheit und ein Sprachdesign einführt, das häufige Fehler innerhalb der Implementierungen verhindert.
 
 ## Ein Paketmanager und Build-System für bestehende Projekte
 

--- a/content/zsf/index.de.md
+++ b/content/zsf/index.de.md
@@ -7,7 +7,7 @@ date: 2020-10-20T16:29:51+02:00
 {{< sponsor-title-cta "Die Zig Software Foundation unterstützen" >}}
 
 ## Auftrag
-Der Auftrag der Zig Software Foundation ist es, die Programmmiersprache Zig zu fördern, zu schützen und zu entwickeln, um das Wachstum einer diversen und internationalen Gemeinschaft von Zig-Programmierern zu ermöglichen und zu unterstützen und Schülern Bildung und Hilfe zu bieten, um die nächste Generation von Programmierern auszubilden, kompetent und ethisch zu handeln und sich an hohen Standards zu messen.
+Der Auftrag der Zig Software Foundation ist es, die Programmiersprache Zig zu fördern, zu schützen und zu entwickeln, um das Wachstum einer diversen und internationalen Gemeinschaft von Zig-Programmierern zu ermöglichen und zu unterstützen und Schülern Bildung und Hilfe zu bieten, um die nächste Generation von Programmierern auszubilden, kompetent und ethisch zu handeln und sich an hohen Standards zu messen.
 
 **Die ZSF ist eine amerikanische *501(c)(3) organization*.** Finanzen, Sitzungsprotokolle und andere Details sind [öffentlich verfügbar](https://drive.google.com/drive/folders/1ucHARxVbhrBbuZDbhrGHYDTsYAs8_bMH?usp=sharing).
 
@@ -21,7 +21,7 @@ Der Auftrag der Zig Software Foundation ist es, die Programmmiersprache Zig zu f
 
 Indem du der ZSF spendest, finanzierst du die Entwicklung der Programmiersprache Zig und ihrem Ökosystem, was wiederum der gesamten Open-Source-Community hilft. Mitglieder der Zig-Community haben zu Bugfixes in [LLVM](https://llvm.org/), [Wine](https://winehq.org/), [QEMU](https://qemu.org/), [musl libc](https://musl.libc.org/), [GDB](https://www.gnu.org/software/gdb/) und anderen Projekten beigetragen.
 
-Die ZSF ist eine kleine Organisation, die ihre Mittel effizient nutzt. Der Plan ist es, das zu erhalten, aber wir möchten unbezahle Freiwillige zu bezahlten Unterstützern machen, um Pullrequests zu mergen und das 1.0-Release schneller zu erreichen. Der ganze Sinn der Non-Profit-Organisation ist es, Leuten zugute zu kommen. Wir versuchen, Open-Source-Unterstützer für ihre Zeit zu bezahlen.
+Die ZSF ist eine kleine Organisation, die ihre Mittel effizient nutzt. Der Plan ist es, das zu erhalten, aber wir möchten unbezahlte Freiwillige zu bezahlten Unterstützern machen, um Pullrequests zu mergen und das 1.0-Release schneller zu erreichen. Der ganze Sinn der Non-Profit-Organisation ist es, Leuten zugute zu kommen. Wir versuchen, Open-Source-Unterstützer für ihre Zeit zu bezahlen.
 
 Der einfachste Weg, uns zu unterstützen, ist ein Spende über [GitHub Sponsors](https://github.com/sponsors/ziglang).
 
@@ -33,7 +33,7 @@ Nützliche Informationen, um auf anderem Wege als durch GitHub Sponsors zu spend
 |-------------|-------------|
 | 84-5105214  | Zig Software Foundation  <br> 1732 1st Ave #21385  <br> New York, NY 10128|
 
-### Weitere unterstützte Spendenmethoden
+### Weitere unterstützte Spendenwege
 - Schecks (s. Postadresse oben)
 - Banküberweisungen (auch von außerhalb der US, kontaktiere uns für weitere Informationen)
 - [Benevity](https://benevity.com) (empfohlen, wenn dein Arbeitgeber Spenden ausgleicht!)


### PR DESCRIPTION
Found `aspell` a little too late. Oops.