### PR TITLE
docs search: enhance history UX

### DIFF
--- a/content/documentation/master/std/main.js
+++ b/content/documentation/master/std/main.js
@@ -1844,7 +1844,13 @@
         var oldHash = location.hash;
         var parts = oldHash.split("?");
         var newPart2 = (domSearch.value === "") ? "" : ("?" + domSearch.value);
-        location.hash = (parts.length === 1) ? (oldHash + newPart2) : (parts[0] + newPart2);
+        var maybeHash = oldHash.startsWith("#") ? "" : "#";
+        if (parts.length === 1) {
+            history.pushState(null, null, maybeHash + oldHash + newPart2);
+        } else {
+            history.replaceState(null, null, maybeHash + parts[0] + newPart2);
+        }
+        onHashChange();
     }
     function getSearchTerms() {
         var list = curNavSearch.trim().split(/[ \r\n\t]+/);


### PR DESCRIPTION
Before this change every keypress causes a history entry, which makes
navigating back annoying. This change switches from location.hash to the
History API which allows more fine-grained control of history entries.

On first keypress in the search field, a new history entry is created.
On subsequent keypresses, the most recent history entry is replaced.
Therefore a typical history after searching and navigating to an entry
might look like

1. documentation root
2. search page "print"
3. docs for `std.debug.print`

This change will make the search incompatible with legacy browsers (IE9
and older). If that's a problem I can write a Location API based
fallback. However, I expect handling the 11MB data.js in such browsers
to be problematic anyway.