### PR TITLE
redirect `/documentation/` to `/documentation/master/`

### DIFF
--- a/content/documentation/index.html
+++ b/content/documentation/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Zig Documentation</title>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="refresh" content="7; url='./master/'" />
+    </head>
+    <body>
+        <p><a href="./master/">Click here</a> if you haven't been redirected...</p>
+    </body>
+</html>


### PR DESCRIPTION
Currently this yields a AWS error such as the following

```
403 Forbidden

    Code: AccessDenied
    Message: Access Denied
    RequestId: DGAHETEJYRDGHER
    HostId: dvsdffljkfhlwejhiuewvkjdsbvkjleubiWEJBEWBIWEvewVKDJVBW+L6Ok=
```
