### PR TITLE
Problem: incorrectly dated 0.8.0

### DIFF
--- a/data/releases.json
+++ b/data/releases.json
@@ -41,7 +41,7 @@
     }
   },
   "0.8.0": {
-    "date": "2020-06-04",
+    "date": "2021-06-04",
     "docs": "https://ziglang.org/documentation/0.8.0/",
     "stdDocs": "https://ziglang.org/documentation/0.8.0/std/",
     "notes": "https://ziglang.org/download/0.8.0/release-notes.html",


### PR DESCRIPTION
Solution: change 2020 to 2021