### PR TITLE
Fix a UB bug (seg fault) in the example code for Queue.deque

### DIFF
--- a/assets/zig-code/samples/4-generic-type.zig
+++ b/assets/zig-code/samples/4-generic-type.zig
@@ -27,10 +27,14 @@ pub fn Queue(comptime Child: type) type {
             this.end = node;
         }
         pub fn dequeue(this: *This) ?Child {
-            if (this.start == null) return null;
-            const start = this.start.?;
+            const start = this.start orelse return null;
             defer this.alloc.destroy(start);
-            this.start = start.next;
+            if (start.next) |next|
+                this.start = next
+            else {
+                this.start = null;
+                this.end = null;
+            }
             return start.data;
         }
     };
@@ -50,5 +54,9 @@ test "queue" {
     try std.testing.expectEqual(int_queue.dequeue(), 50);
     try std.testing.expectEqual(int_queue.dequeue(), 75);
     try std.testing.expectEqual(int_queue.dequeue(), 100);
+    try std.testing.expectEqual(int_queue.dequeue(), null);
+
+    try int_queue.enqueue(5);
+    try std.testing.expectEqual(int_queue.dequeue(), 5);
     try std.testing.expectEqual(int_queue.dequeue(), null);
 }


### PR DESCRIPTION
The problem happens when enqueuing an item after dequeuing all other items.

I found this some time ago when learning Zig and I'm finally getting around to
making a PR. I should have done it earlier since the code has probably been
copied many times now.

The following failure occurs after changing the test to enqueue after dequeuing
all items. It is fixed by the change to the dequeue function.

~/www.ziglang.org$ zig test assets/zig-code/samples/4-generic-type.zig
Code Generation [926/945] std.io.writer.Writer(std.fs.file.File,std.os.WriteErro..Test [1/1] test "queue"... Segmentation fault at address 0x7f27ae695038
/home/ubuntu/www.ziglang.org/assets/zig-code/samples/4-generic-type.zig:25:44: 0x208531 in Queue(i32).enqueue (test)
            if (this.end) |end| end.next = node //
                                           ^
/home/ubuntu/www.ziglang.org/assets/zig-code/samples/4-generic-type.zig:55:26: 0x207abd in test "queue" (test)
    try int_queue.enqueue(5);
...