### PR TITLE
Fix documentation oversight.

### DIFF
--- a/content/learn/overview.ar.md
+++ b/content/learn/overview.ar.md
@@ -72,7 +72,7 @@ bar();
 
 حين يصرف هذا المثال بوضعية `O ReleaseSmall-` مع نزع رموز التشخيص، واستعمال وضعية سلسلة التعليمات الواحدة، نحصل على برنامج تنفيذي بحجم 9.8 KiB يستهدف x86_64-linux:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -81,7 +81,7 @@ $ ldd hello
 
 استهداف Windows يصغر حجم البرنامج التنفيذي ليصبح 4096 بايت.
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -72,7 +72,7 @@ Zigs Standardbibliothek kann libc einbeziehen, aber ist nicht darauf angewiesen.
 
 Mit `-O ReleaseSmall` kompiliert, ohne Debugsymbole, im Single Thread-Modus, wird für das Target x86_64-linux eine 9.8 KiB große statische Programmdatei erzeugt:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -81,7 +81,7 @@ $ ldd hello
 
 Ein Build auf Windows ist noch kleiner, nur 4096 Bytes:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.en.md
+++ b/content/learn/overview.en.md
@@ -73,7 +73,7 @@ The Zig Standard Library integrates with libc, but does not depend on it. Here's
 
 When compiled with `-O ReleaseSmall`, debug symbols stripped, single-threaded mode, this produces a 9.8 KiB static executable for the x86_64-linux target:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 A Windows build is even smaller, coming out to 4096 bytes:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.es.md
+++ b/content/learn/overview.es.md
@@ -72,7 +72,7 @@ La biblioteca estándar de Zig se integra con libc, pero no depende de ella. Aqu
 
 Al compilar con `-O ReleaseSmall`, lo cual remueve símbolos de depuración y es un modo single-threaded, se produce un ejecutable estático de 9.8 KiB para la arquitectura x86_64-linux:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -81,7 +81,7 @@ $ ldd hello
 
 En Windows se produce una compilación aún mas pequeña, llegando a 4096 bytes:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.fa.md
+++ b/content/learn/overview.fa.md
@@ -73,7 +73,7 @@ Runtime در ساخت های دارای ایمنی:
 
 هنگامی که با `-O ReleaseSmall` علامت های اشکال زدایی برداشته می شوند و حالت تک رشته ای ایجاد می شود، Zig فایل اجرایی 9.8 KiB برای هدف x86_64-linux تولید می کند:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 این ساخت در ویندوز حتی کوچک تر است و به 4KB میرسد:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.fr.md
+++ b/content/learn/overview.fr.md
@@ -82,7 +82,7 @@ Voici un Hello World :
 
 Quand ce code est compilé avec `-O ReleaseSmall`, les symboles de debug retirés, sur un seul fil d'exécution, cela produit un binaire statique de 9.8 KiB pour la cible x86_64 :
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -91,7 +91,7 @@ $ ldd hello
 
 Le binaire produit pour Windows est encore plus petit, seulement 4096 octets :
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.ko.md
+++ b/content/learn/overview.ko.md
@@ -73,7 +73,7 @@ Zig 표준 라이브러리는 libc와 연동하지만, 의존하지는 않습니
 
 x86_64-linux 타겟으로 `-O ReleaseSmall`에 디버그 심볼을 제거하고 단일 쓰레드 모드로 컴파일 하면, 정적으로 컴파일된 9.9 KiB의 실행파일이 만들어집니다:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 Windows용 빌드는 더 작아서, 4096 byte입니다:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.pt.md
+++ b/content/learn/overview.pt.md
@@ -73,7 +73,7 @@ A biblioteca padrão do Zig se integra com a libc, mas não depende dela. Aqui e
 
 Quando compilado com `-O ReleaseSmall`, símbolos de depuração são removidos (stripped), modo de thread única, isto produz um executável estático de 9,8 KiB para a plataforma x86_64-linux:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 No Windows é ainda menor, gerando um binário de 4096 bytes:
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.zh.md
+++ b/content/learn/overview.zh.md
@@ -73,7 +73,7 @@ Zig 标准库里集成了 libc，但是不依赖于它：
 
 当使用 `-O ReleaseSmall` 并移除调试符号，单线程模式构建，可以产生一个以 x86_64-linux 为目标的 9.8 KiB 的静态可执行文件：
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 Windows 的构建就更小了，仅仅 4096 字节：
 ```
-$ zig build-exe hello.zig --release-small --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe


### PR DESCRIPTION
At some point --release-small was
removed in favor of -O ReleaseSmall.