### PR TITLE
Fix bug that prevents scrolling on small devices

### DIFF
--- a/content/documentation/0.6.0/std/index.html
+++ b/content/documentation/0.6.0/std/index.html
@@ -461,7 +461,8 @@
         }
         .flex-main {
           flex-direction: column;
-          display: flex;
+          display: block;
+          overflow-y: auto;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.6.0/std/index.html
+++ b/content/documentation/0.6.0/std/index.html
@@ -461,7 +461,7 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
+          display: flex;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.7.0/std/index.html
+++ b/content/documentation/0.7.0/std/index.html
@@ -461,7 +461,8 @@
         }
         .flex-main {
           flex-direction: column;
-          display: flex;
+          display: block;
+          overflow-y: auto;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.7.0/std/index.html
+++ b/content/documentation/0.7.0/std/index.html
@@ -461,7 +461,7 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
+          display: flex;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.7.1/std/index.html
+++ b/content/documentation/0.7.1/std/index.html
@@ -461,7 +461,8 @@
         }
         .flex-main {
           flex-direction: column;
-          display: flex;
+          display: block;
+          overflow-y: auto;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.7.1/std/index.html
+++ b/content/documentation/0.7.1/std/index.html
@@ -461,7 +461,7 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
+          display: flex;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.8.0/std/index.html
+++ b/content/documentation/0.8.0/std/index.html
@@ -460,7 +460,8 @@
         }
         .flex-main {
           flex-direction: column;
-          display: flex;
+          display: block;
+          overflow-y: auto;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.8.0/std/index.html
+++ b/content/documentation/0.8.0/std/index.html
@@ -460,7 +460,7 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
+          display: flex;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.8.1/std/index.html
+++ b/content/documentation/0.8.1/std/index.html
@@ -460,7 +460,8 @@
         }
         .flex-main {
           flex-direction: column;
-          display: flex;
+          display: block;
+          overflow-y: auto;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/0.8.1/std/index.html
+++ b/content/documentation/0.8.1/std/index.html
@@ -460,7 +460,7 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
+          display: flex;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/master/std/index.html
+++ b/content/documentation/master/std/index.html
@@ -460,7 +460,8 @@
         }
         .flex-main {
           flex-direction: column;
-          display: flex;
+          display: block;
+          overflow-y: auto;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);

--- a/content/documentation/master/std/index.html
+++ b/content/documentation/master/std/index.html
@@ -460,7 +460,7 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
+          display: flex;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);


### PR DESCRIPTION
As referenced in [this issue on the main zig repository](https://github.com/ziglang/zig/issues/9263), there was a bug in the website's code that prevents scrolling through std docs on mobile devices. To fix this, I took the changes as prescribed in that issue, adding `overflow-y: auto;` to the .flex-main class on the CSS. 