### PR TITLE
Fix font style for functions in std docs

### DIFF
--- a/content/documentation/master/std/main.js
+++ b/content/documentation/master/std/main.js
@@ -1035,12 +1035,12 @@
         }
 
         if (fnsList.length !== 0) {
-            var domListFnsFragment = createDomListFragment(fnsList.length, '<tr><td></td><td></td></tr>');
+            var domListFnsFragment = createDomListFragment(fnsList.length, '<tr><td><code class="zig"></code></td><td></td></tr>');
             for (var i = 0; i < fnsList.length; i += 1) {
                 var decl = fnsList[i];
                 var trDom = domListFnsFragment.children[i];
 
-                var tdFnCode = trDom.children[0];
+                var tdFnCode = trDom.children[0].firstChild;
                 var tdDesc = trDom.children[1];
 
                 tdFnCode.innerHTML = typeIndexName(decl.type, true, true, decl, navLinkDecl(decl.name), thisTypes);

--- a/content/documentation/master/std/main.js
+++ b/content/documentation/master/std/main.js
@@ -273,11 +273,11 @@
                     renderContainer(fnObj.combined, calls.map(function (call) { return zigAnalysis.calls[call].result.value }));
                 }
 
-                var domListFnExamplesFragment = createDomListFragment(calls.length, '<li></li>');
+                var domListFnExamplesFragment = createDomListFragment(calls.length, '<li><code class="zig"></code></li>');
 
                 for (var callI = 0; callI < calls.length; callI += 1) {
-                    var liDom = domListFnExamplesFragment.children[callI];
-                    liDom.innerHTML = getCallHtml(fnDecl, calls[callI]);
+                    var codeDom = domListFnExamplesFragment.children[callI].firstChild;
+                    codeDom.innerHTML = getCallHtml(fnDecl, calls[callI]);
                 }
 
                 domListFnExamples.innerHTML = "";


### PR DESCRIPTION
Wrap function signatures and examples in `code` blocks to use uniform styling (e.g. fixed-width fonts).