### PR TITLE
perf: don't use transparent white for sticky header

### DIFF
--- a/themes/ziglang-original/assets/css/perf.css
+++ b/themes/ziglang-original/assets/css/perf.css
@@ -39,7 +39,7 @@ p.benchmark-source {
 }
 
 div.perf-settings {
-    background-color: white;
+    background-color: #fff;
     position:  sticky;
     padding:  0px;
     margin:  0px;
@@ -307,7 +307,7 @@ svg.cpu_cycles > path.area {
     }
 
     div.perf-settings {
-        background-color: #11111155;
+        background-color: #111;
         color: #bbb;
     }
 }

--- a/themes/ziglang-original/assets/css/perf.css
+++ b/themes/ziglang-original/assets/css/perf.css
@@ -39,7 +39,7 @@ p.benchmark-source {
 }
 
 div.perf-settings {
-    background-color: #ffffff55;
+    background-color: white;
     position:  sticky;
     padding:  0px;
     margin:  0px;


### PR DESCRIPTION
This change prevents the body content from passing through the background of the sticky header

### Before
![image](https://user-images.githubusercontent.com/5464072/144779737-62638f3d-abda-4f50-862a-5f44badcfd31.png)

### After
![image](https://user-images.githubusercontent.com/5464072/144779707-ebe9860b-3bf5-4656-b479-1816d5277d1a.png)
