### PR TITLE
Perf Updates #2

### DIFF
--- a/static/perf/perf.js
+++ b/static/perf/perf.js
@@ -490,10 +490,6 @@ function drawRangeAreaChart(benchmark, measurement, data, options, toNode) {
         .attr("cy", (d) => {
             return yAxisArea(d[primaryMeasurementKey]);
         })
-        .attr("r", 0)
-        .attr("fill", "orange")
-        .attr("stroke", "orange")
-        .attr("stroke-width", "1px")
         .attr("class", "circle");
 
     // X-Axis

--- a/themes/ziglang-original/assets/css/perf.css
+++ b/themes/ziglang-original/assets/css/perf.css
@@ -197,22 +197,17 @@ div.tooltip > div.records > table tr td:nth-child(4) {
 /* Focus Indicators */
 line.line.focus.y {
     stroke:  currentColor;
-    /*stroke:  #F7A41D55;*/
     stroke-width: 1px;
     fill: none;
 }
 
 circle.circle.focus {
-    /*fill:  #F7A41D55;*/
     fill:  currentColor;
-    /*stroke:  currentColor;*/
-    /*stroke:  #F7A41D55;*/
-    /*stroke-width: 1px;*/
+    stroke:  none;
 }
 
-/* D3 Charts */
+
 path.line {
-    stroke:  #F7A41D;
     stroke-width: 1px;
     fill: none;
 }
@@ -230,12 +225,69 @@ path.line.primary {
 }
 
 path.area.range {
-    fill: #F7A41D;
     fill-opacity: 0.1;
 }
 
+path.area.range {
+    stroke:  none;
+}
+
+/* CPU Cycles Colors */
+.cpu_cycles {
+    stroke:  #6e40aa;
+    fill:  #6e40aa;
+}
+
+/* CPU Instructions Colors */
+.instructions {
+    stroke:  #c83dac;
+    fill:  #c83dac;
+}
+
+/* Cache References Colors */
+.cache_references {
+    stroke:  #ff5375;
+    fill:  #ff5375;
+}
+
+/* Cache Misses Colors */
+.cache_misses {
+    stroke:  #ff8c38;
+    fill:  #ff8c38;
+}
+
+/* Wall Time Colors */
+.wall_time {
+    stroke:  #c9d33a;
+    fill:  #c9d33a;
+}
+
+/* User-Space Time Colors */
+.utime {
+    stroke:  #79f659;
+    fill:  #79f659;
+}
+
+/* Kernel Time Colors */
+.stime {
+    stroke:  #28ea8d;
+    fill:  #28ea8d;
+}
+
+/* Branch Misses Colors */
+.branch_misses {
+    stroke:  #1eb8d0;
+    fill:  #1eb8d0;
+}
+
+/* Max RSS Colors */
+.maxrss {
+    stroke:  #4775de;
+    fill:  #4775de;
+}
+
 text.axis.y.title {
-    /*fill:  #F7A41D;*/
+    stroke:  none;
     fill:  currentColor;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     text-anchor: middle;
@@ -249,11 +301,11 @@ text.axis.y {
 }
 
 g.tick>line {
-    /*stroke: #F7A41D;*/
     stroke: currentColor;
 }
 
 g.tick>text {
+    stroke:  none;
     fill: currentColor;
 }
 g.axis.x>g.tick>text {
@@ -269,28 +321,14 @@ g.axis.y>g.tick>text {
 }
 
 g.axis.y>path.domain {
-    /*stroke: #F7A41D;*/
-    fill:  none;
     stroke: currentColor;
+    fill:  none;
 }
 
 g.axis.x>path.domain {
-    /*stroke: #F7A41D;*/
     stroke: currentColor;
     fill:  none;
 }
-
-/*.cpu_cycles > svg, path, area {
-    stroke: red;
-    fill:  red;
-}
-*/
-/*
-svg.cpu_cycles > path.area {
-    stroke: red;
-    fill:  red;
-
-}*/
 
 @media (prefers-color-scheme:dark) {
     #header-image-performance {


### PR DESCRIPTION
This is a work-in-progress. I'll edit the post or add comments as I make commits along with an explanation.

# Per-measurement colors
I'm not yet sold on this, but my thinking is that it'll make it easier for frequent users of the perf charts to identify which metric they're looking at, without having to scan over to the y-axis label. This will be even more important with a future change I want to try, which is to remove the "duplicate" x-axis labels, and push the charts closer together vertically. The goal of all this is to make more chart data visible without scrolling, to allow spotting relationships between the  measurements.
  
The colors were chosen based on their hue separation. The problem with doing it this way is that some colors will be brighter than others. I have some tools to select colors from a perceptually uniform color space, this should give us colors that appear/feel equally far apart, and don't have this issue. I'll do that later though, and these look good enough for now™.
    
![image](https://user-images.githubusercontent.com/2127629/144898562-05cba172-8ac5-4f65-a331-e9ddc2373e1e.png)
