### PR TITLE
clarify wording for `@round` builtin

### DIFF
--- a/content/documentation/master/index.html
+++ b/content/documentation/master/index.html
@@ -11228,7 +11228,7 @@
 
       <pre><code><span class="line"><span class="tok-builtin">@round</span>(value: <span class="tok-kw">anytype</span>) <span class="tok-builtin">@TypeOf</span>(value)</span></code></pre>
       <p>
-      Rounds the given floating point number to an integer, away from zero. Uses a dedicated hardware instruction
+      Rounds the given floating point number to the nearest integer, away from zero. Uses a dedicated hardware instruction
       when available.
       </p>
       <p>


### PR DESCRIPTION
The previous text made it seem like it would always round up for positive floats (and down for negative floats), which is not the case.