### PR TITLE
[]T pointer confusion in docs.

### DIFF
--- a/content/documentation/master/index.html
+++ b/content/documentation/master/index.html
@@ -3244,7 +3244,7 @@
             </li>
         </ul>
         <ul>
-            <li><code><span class="line">[]T</span></code> - pointer to runtime-known number of items.
+            <li><code><span class="line">[]T</span></code> - is a slice (a fat pointer, which contains a pointer of type [*]T and a length).
             <ul>
                 <li>Supports index syntax: <code><span class="line">slice[i]</span></code></li>
                 <li>Supports slice syntax: <code><span class="line">slice[start..end]</span></code></li>


### PR DESCRIPTION
saying []T is a pointer is confusing because zig docs say there are two types of pointers (*T and [*]T). It is more clear to say that []T is a slice type which contains a [*]T pointer and a length.