### PR TITLE
Soften language in why_zig_rust_d_cpp.en.md

### DIFF
--- a/content/learn/why_zig_rust_d_cpp.en.md
+++ b/content/learn/why_zig_rust_d_cpp.en.md
@@ -88,7 +88,7 @@ One of the holy grails of programming is code reuse. Sadly, in practice, we find
 
 ## A Package Manager and Build System for Existing Projects
 
-Zig is a programming language, but it also ships with a build system and package manager that are intended to be useful even in the context of a traditional C/C++ project.
+Zig is a programming language, but it also will ship with a build system and package manager that are intended to be useful even in the context of a traditional C/C++ project.
 
 Not only can you write Zig code instead of C or C++ code, but you can use Zig as a replacement for autotools, cmake, make, scons, ninja, etc. And on top of this, it (will) provide a package manager for native dependencies. This build system is intended to be appropriate even if the entirety of a project's codebase is in C or C++.
 


### PR DESCRIPTION
Based on the rest of the text I guess this was meant to say that Zig intends to ship with a package manager rather than that it already ships with one. But this is a guess on my part so feel free to reject.

The context for this is https://news.ycombinator.com/item?id=34136704.

Btw how do updates to the translated articles get made?