### PR TITLE
remove broken links to `oxid` repository

### DIFF
--- a/content/learn/overview.ar.md
+++ b/content/learn/overview.ar.md
@@ -122,7 +122,7 @@ hello.exe: PE32+ executable (console) x86-64, for MS Windows
 
 أي مكتبة مكتوبة بلغة Zig صالحة للاستخدام في أي مكان:
 
-- [برامج للأجهزة الشخصية](https://github.com/TM35-Metronome/) و[ألعاب](https://github.com/dbandstra/oxid)
+- [برامج للأجهزة الشخصية](https://github.com/TM35-Metronome/)
 - خوادم سريعة الاستجابة
 - [أنوية أنظمة التشغيل](https://github.com/AndreaOrru/zen)
 - [الأجهزة المدمجة](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -122,7 +122,7 @@ Dieselbe Syntax funktioniert mit [while](https://ziglang.org/documentation/maste
 
 Eine in Zig verfasste Bibliothek kann überall verwendet werden:
 
-- [Desktopanwendungen](https://github.com/TM35-Metronome/) & [Spiele](https://github.com/dbandstra/oxid)
+- [Desktopanwendungen](https://github.com/TM35-Metronome/)
 - Server mit geringer Latenz
 - [Betriebssystemkernel](https://github.com/AndreaOrru/zen)
 - [Embedded-Geräte](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.en.md
+++ b/content/learn/overview.en.md
@@ -123,7 +123,7 @@ Another option is to use if:
 
 A library written in Zig is eligible to be used anywhere:
 
-- [Desktop applications](https://github.com/TM35-Metronome/) & [games](https://github.com/dbandstra/oxid)
+- [Desktop applications](https://github.com/TM35-Metronome/)
 - Low latency servers
 - [Operating System kernels](https://github.com/AndreaOrru/zen)
 - [Embedded devices](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.es.md
+++ b/content/learn/overview.es.md
@@ -122,7 +122,7 @@ La misma sintaxis funciona con [while](https://ziglang.org/documentation/master/
 
 Una biblioteca escrita en Zig es elegible para ser usada en cualquier lugar:
 
-- [Aplicaciones de escritorio](https://github.com/TM35-Metronome/) y [juegos](https://github.com/dbandstra/oxid)
+- [Aplicaciones de escritorio](https://github.com/TM35-Metronome/)
 - Servidores de baja latencia
 - [Kernels de sistemas operativos](https://github.com/AndreaOrru/zen)
 - [Dispositivos embebidos](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.fa.md
+++ b/content/learn/overview.fa.md
@@ -123,7 +123,7 @@ hello.exe: PE32+ executable (console) x86-64, for MS Windows
 
 کتابخانه ای که به زبان زیگ نوشته شده است، می تواند در هر مکانی مورد استفاده قرار گیرد:
 
-- [نرم افزار های دسکتاپ](https://github.com/TM35-Metronome/) & [games](https://github.com/dbandstra/oxid)
+- [نرم افزار های دسکتاپ](https://github.com/TM35-Metronome/)
 - سرورهای با تاخیر کم
 - [کرنل سیستم هامل ها](https://github.com/AndreaOrru/zen)
 - [دستگاه های Embedded](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.fr.md
+++ b/content/learn/overview.fr.md
@@ -133,7 +133,7 @@ Cette syntaxe fonctionne également avec [while (EN)](https://ziglang.org/docume
 
 Une bibliothèque écrite en Zig peut être utilisée n'importe où :
 
-- [Applications de bureau](https://github.com/TM35-Metronome/) & [jeux](https://github.com/dbandstra/oxid)
+- [Applications de bureau](https://github.com/TM35-Metronome/)
 - Serveur basse latence
 - [Noyaux de systèmes d'exploitation](https://github.com/AndreaOrru/zen)
 - [Embarqué](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.ja.md
+++ b/content/learn/overview.ja.md
@@ -123,7 +123,7 @@ hello.exe: PE32+ executable (console) x86-64, for MS Windows
 
 Zigで書かれたライブラリは、どこでも使用することができます：
 
-- [デスクトップアプリケーション](https://github.com/TM35-Metronome/) & [ゲーム](https://github.com/dbandstra/oxid)
+- [デスクトップアプリケーション](https://github.com/TM35-Metronome/)
 - 低レイテンシーサーバ
 - [OSカーネル](https://github.com/AndreaOrru/zen)
 - [組込み機器](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.ko.md
+++ b/content/learn/overview.ko.md
@@ -123,7 +123,7 @@ hello.exe: PE32+ executable (console) x86-64, for MS Windows
 
 Zig로 작성한 라이브러리는 어디에나 쓸 수 있습니다:
 
-- [데스크탑 애플리케이션](https://github.com/TM35-Metronome/) & [게임](https://github.com/dbandstra/oxid)
+- [데스크탑 애플리케이션](https://github.com/TM35-Metronome/)
 - 지연시간이 짧은 서버
 - [운영체제 커널](https://github.com/AndreaOrru/zen)
 - [임베디드 장치](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.pt.md
+++ b/content/learn/overview.pt.md
@@ -123,7 +123,7 @@ Outra opção é usar `if`:
 
 Uma biblioteca escrita em Zig é elegível para ser usada em qualquer lugar:
 
-- [Aplicações desktop](https://github.com/TM35-Metronome/) & [Jogos](https://github.com/dbandstra/oxid)
+- [Aplicações desktop](https://github.com/TM35-Metronome/)
 - Servidores de baixa latência
 - [Kernel do Sistema Operacional](https://github.com/AndreaOrru/zen)
 - [Dispositívos Embarcados](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.ru.md
+++ b/content/learn/overview.ru.md
@@ -124,7 +124,7 @@ hello.exe: PE32+ executable (console) x86-64, for MS Windows
 
 Библиотека, написанная на Zig, может быть использована где угодно:
 
-- [Настольными приложениями](https://github.com/TM35-Metronome/) и [играми](https://github.com/dbandstra/oxid)
+- [Настольными приложениями](https://github.com/TM35-Metronome/)
 - Серверами с низкой задержкой
 - [Ядрами операционных систем](https://github.com/AndreaOrru/zen)
 - [Встраиваемыми устройствами](https://github.com/skyfex/zig-nrf-demo/)

--- a/content/learn/overview.zh.md
+++ b/content/learn/overview.zh.md
@@ -122,7 +122,7 @@ hello.exe: PE32+ executable (console) x86-64, for MS Windows
 
 用Zig编写的库可以在任何地方使用：
 
-- [桌面程序](https://github.com/TM35-Metronome/)和[游戏](https://github.com/dbandstra/oxid)
+- [桌面程序](https://github.com/TM35-Metronome/)
 - 低延迟服务器
 - [操作系统内核](https://github.com/AndreaOrru/zen)
 - [嵌入式设备](https://github.com/skyfex/zig-nrf-demo/)


### PR DESCRIPTION
Links to the `oxid` repository seem to be broken (404: https://github.com/dbandstra/oxid), and  I didn't find a renamed repository.

This removes the broken links.