### PR TITLE
Update update-download-page.zig ziglang/zig#14671

### DIFF
--- a/.github/workflows/update-download-page.zig
+++ b/.github/workflows/update-download-page.zig
@@ -43,7 +43,7 @@ fn render(
     var state = State.Start;
     var var_name_start: usize = undefined;
     var line: usize = 1;
-    for (in_contents) |byte, index| {
+    for (in_contents, 0..) |byte, index| {
         switch (state) {
             State.Start => switch (byte) {
                 '{' => {


### PR DESCRIPTION
build tarballs actions is currently failing with:

```
2023-02-20T13:15:31.0941982Z + /home/ci/actions-runner/_work/zig-bootstrap/out/host/bin/zig run update-download-page.zig
2023-02-20T13:15:31.1122068Z update-download-page.zig:46:30: error: extra capture in for loop
2023-02-20T13:15:31.1122748Z     for (in_contents) |byte, index| {
2023-02-20T13:15:31.1123276Z                              ^~~~~
2023-02-20T13:15:31.1124165Z update-download-page.zig:46:30: note: run 'zig fmt' to upgrade your code automatically
2023-02-20T13:15:31.1193698Z ##[error]Process completed with exit code 1.
```