### PR TITLE
make example to show result even with ReleaseFast or ReleaseSmall

### DIFF
--- a/assets/zig-code/index.zig
+++ b/assets/zig-code/index.zig
@@ -27,3 +27,8 @@ pub fn main() !void {
     }
     std.log.info("up={d}", .{config.uptime});
 }
+
+// Make std.log.inf(...); works even with ReleaseFast or ReleaseSmall
+pub const log_level: std.log.Level = .info;
+
+


### PR DESCRIPTION
from discussion in https://github.com/ziglang/zig/issues/14738
Make the frontpage example work even if the new user use:
zig build-exe -O ReleaseSmall index.zig
