### PR TITLE
Fix code example

### DIFF
--- a/assets/zig-code/features/20-reflection.zig
+++ b/assets/zig-code/features/20-reflection.zig
@@ -18,7 +18,7 @@ fn printInfoAboutStruct(comptime T: type) void {
             .{
                 @typeName(T),
                 field.name,
-                @typeName(field.type),
+                @typeName(field.field_type),
             },
         );
     }


### PR DESCRIPTION
Running this code example was returning the following error:

```
reflection.zig:20:33: error: no field named 'type' in struct 'builtin.Type.StructField'
                @typeName(field.type),
                                ^~~~
/opt/homebrew/Cellar/zig/0.10.1/lib/zig/std/builtin.zig:283:29: note: struct declared here
    pub const StructField = struct {
                            ^~~~~~
```