### PR TITLE
Fix PT translation of `Coding Interview` in  "Zigg Zagg" section

### DIFF
--- a/content/learn/samples.pt.md
+++ b/content/learn/samples.pt.md
@@ -17,7 +17,7 @@ Exemplo de importação de um arquivo de cabeçalho C e vinculação tanto à li
 
 
 ## Zigg Zagg
-Zig é *optimizado* para codificar declarações (não exatamente!!).
+Zig é *optimizado* para entrevista de codificação (não exatamente!!).
 
 {{< zigdoctest "assets/zig-code/samples/3-ziggzagg.zig" >}}
 

--- a/content/learn/samples.pt.md
+++ b/content/learn/samples.pt.md
@@ -17,7 +17,7 @@ Exemplo de importação de um arquivo de cabeçalho C e vinculação tanto à li
 
 
 ## Zigg Zagg
-Zig é *optimizado* para entrevista de codificação (não exatamente!!).
+Zig é *optimizado* para entrevistas de codificação (não exatamente!!).
 
 {{< zigdoctest "assets/zig-code/samples/3-ziggzagg.zig" >}}
 


### PR DESCRIPTION
On `learn/samples/#zigg-zagg`, it says in English `Zig is optimized for coding interviews (not really).`.

The current Portuguese translation says `Zig é optimizado para codificar declarações (não exatamente!!).`, which translates to something like `Zig is optimized to coding declarations (not really!!)`, so I think this is a better translation.