### PR TITLE
Fix Build Error in Memory Leak Example

### DIFF
--- a/assets/zig-code/samples/1-memory-leak.zig
+++ b/assets/zig-code/samples/1-memory-leak.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 
 pub fn main() !void {
     var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    defer std.debug.assert(general_purpose_allocator.deinit() == .ok);
+    defer std.debug.assert(!general_purpose_allocator.deinit());
 
     const gpa = general_purpose_allocator.allocator();
 


### PR DESCRIPTION
The current example fails to build due to a bool being compared to an enum literal. Change the example to allow for the build to complete.

Current:
```
error: incompatible types: 'bool' and '@TypeOf(.enum_literal)'
    defer std.debug.assert(general_purpose_allocator.deinit() == .ok);
```

Update:
```
error(gpa): memory address 0x103110000 leaked:
/src/main.zig:10:35: 0x102f84b9b in main
    const u32_ptr = try gpa.create(u32);
                                  ^
/opt/homebrew/Cellar/zig/0.10.1/lib/zig/std/start.zig:614:37: 0x102f852eb in main
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x197e17f27 in ??? (???)
???:?:?: 0x435cffffffffffff in ??? (???)


thread 2057375 panic: reached unreachable code
/opt/homebrew/Cellar/zig/0.10.1/lib/zig/std/debug.zig:278:14: 0x102f84ebb in assert
    if (!ok) unreachable; // assertion failure
             ^
/src/main.zig:6:61: 0x102f84c23 in main (breezy)
    defer std.debug.assert(!general_purpose_allocator.deinit());
                                                            ^
/opt/homebrew/Cellar/zig/0.10.1/lib/zig/std/start.zig:614:37: 0x102f852eb in main
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x197e17f27 in ??? (???)
???:?:?: 0x435cffffffffffff in ??? (???)
```
