### PR TITLE
fix build target typo

### DIFF
--- a/content/learn/overview.ar.md
+++ b/content/learn/overview.ar.md
@@ -72,7 +72,7 @@ bar();
 
 حين يصرف هذا المثال بوضعية `O ReleaseSmall-` مع نزع رموز التشخيص، واستعمال وضعية سلسلة التعليمات الواحدة، نحصل على برنامج تنفيذي بحجم 9.8 KiB يستهدف x86_64-linux:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -81,7 +81,7 @@ $ ldd hello
 
 استهداف Windows يصغر حجم البرنامج التنفيذي ليصبح 4096 بايت.
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.ar.md
+++ b/content/learn/overview.ar.md
@@ -302,15 +302,15 @@ $ zig build test
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-وهذا مثال لإختيار منصات x86_64-windows وx86_64-macosx وaarch64v8-linux:
+وهذا مثال لإختيار منصات x86_64-windows وx86_64-macos وaarch64-linux:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -403,7 +403,7 @@ $ ldd hello
 
 مما يعني أن هذه الخاصية متاحة على كل المنصات. يستطيع مستخدمي Windows وmacOS بناء كود Zig وC، وربط برامجهم بlibc، لأي منصة مذكورة أعلاه. وبالمثل، يمكن ترجمة الكود بشكل مختلط لمعمارية أخرى:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -302,15 +302,15 @@ Zig kann für jedes der Targets im [Support Table](#support-table) mit [Tier 3 S
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Und jetzt Builds für x86_64-windows, x86_64-macosx und aarch64v8-linux:
+Und jetzt Builds für x86_64-windows, x86_64-macos und aarch64-linux:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -402,7 +402,7 @@ In diesem Beispiel hat Zig musls Quellcode kompiliert und verlinkt. Dank dem [Ca
 
 Das bedeutet, dass die Funktionalität auf jeder Plattform verfügbar ist. Nutzer von Windows und macOS können Zig- und C-Code für jedes der obigen Targets kompilieren und gegen libc linken. Auf ähnliche Art und Weise kann Code für andere Prozessorarchitekturen crosskompiliert werden:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
@@ -570,7 +570,7 @@ Zig kommuniziert die Unterstützung von verschiedenen Targets mit "Support Tiers
 
 - Unterstützung für diese Targets ist rein experimentell.
 - LLVM enthält dies möglicherweise als experimentelles Target; damit es verfügbar ist, sind Zig-seitige Dateien oder ein speziell konfiguriertes LLVM-Build notwendig. `zig targets` zeigt das Target an, wenn es verfügbar ist.
-- Dieses Target wird möglicherweise von einer offiziellen Seite als veraltet eingestuft, wie zum Beispiel [macosx/i386](https://support.apple.com/en-us/HT208436); in dem Fall wird es Tier 4 nie verlassen.
+- Dieses Target wird möglicherweise von einer offiziellen Seite als veraltet eingestuft, wie zum Beispiel [macos/i386](https://support.apple.com/en-us/HT208436); in dem Fall wird es Tier 4 nie verlassen.
 - Dieses Target unterstützt möglicherweise nur `--emit asm` und kann keine Objektdateien ausgeben.
 
 ## Einfache Unterstützung von Paketen

--- a/content/learn/overview.de.md
+++ b/content/learn/overview.de.md
@@ -72,7 +72,7 @@ Zigs Standardbibliothek kann libc einbeziehen, aber ist nicht darauf angewiesen.
 
 Mit `-O ReleaseSmall` kompiliert, ohne Debugsymbole, im Single Thread-Modus, wird für das Target x86_64-linux eine 9.8 KiB große statische Programmdatei erzeugt:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -81,7 +81,7 @@ $ ldd hello
 
 Ein Build auf Windows ist noch kleiner, nur 4096 Bytes:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.en.md
+++ b/content/learn/overview.en.md
@@ -303,15 +303,15 @@ Zig can build for any of the targets from the [Support Table](#support-table) wi
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Now to build it for x86_64-windows, x86_64-macosx, and aarch64v8-linux:
+Now to build it for x86_64-windows, x86_64-macos, and aarch64-linux:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -403,7 +403,7 @@ In this example, Zig built musl libc from source and then linked against it. The
 
 This means that this functionality is available on any platform. Windows and macOS users can build Zig and C code, and link against libc, for any of the targets listed above. Similarly code can be cross compiled for other architectures:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```

--- a/content/learn/overview.en.md
+++ b/content/learn/overview.en.md
@@ -73,7 +73,7 @@ The Zig Standard Library integrates with libc, but does not depend on it. Here's
 
 When compiled with `-O ReleaseSmall`, debug symbols stripped, single-threaded mode, this produces a 9.8 KiB static executable for the x86_64-linux target:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 A Windows build is even smaller, coming out to 4096 bytes:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.es.md
+++ b/content/learn/overview.es.md
@@ -72,7 +72,7 @@ La biblioteca estándar de Zig se integra con libc, pero no depende de ella. Aqu
 
 Al compilar con `-O ReleaseSmall`, lo cual remueve símbolos de depuración y es un modo single-threaded, se produce un ejecutable estático de 9.8 KiB para la arquitectura x86_64-linux:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -81,7 +81,7 @@ $ ldd hello
 
 En Windows se produce una compilación aún mas pequeña, llegando a 4096 bytes:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.es.md
+++ b/content/learn/overview.es.md
@@ -302,15 +302,15 @@ Zig puede compilar para cualquiera de los objetivos en [Support Table](#support-
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Para compilar este ejemplo específicamente para arquitecturas x86_64-windows, x86_64-macosx, y aarch64v8-linux:
+Para compilar este ejemplo específicamente para arquitecturas x86_64-windows, x86_64-macos, y aarch64-linux:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -401,7 +401,7 @@ En este ejemplo, Zig compiló musl libc desde los fuentes para luego proceder a 
 
 Esta funcionalidad está disponible en cualquier plataforma. Los usuarios de Windows y macOs pueden compilar código Zig y C y efectuar link con libc para cualquiera de los objetivos listados arriba. De igual forma, el código puede ser compilado entre otras arquitecturas:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
@@ -564,7 +564,7 @@ Zig utilíza un sistema de "support tier" (nivel de soporte) para comunicar el n
 
 - El soporte para estas arquitecturas es completamente experimental
 - Es posible que LLVM tenga esta arquitectura etiquetada como experimental, lo que significa que necesitarás usar binarios ofrecidos por Zig para que esta arquitectura esté disponible, o bien, compilar LLVM desde fuentes con opciones de configuración especiales.
-- Estas arquitecturas pueden haber expirado, por ejemplo [macosx/i386](https://support.apple.com/en-us/HT208436), en cuyo caso quedará perpetuamente en nivel de soporte 4.
+- Estas arquitecturas pueden haber expirado, por ejemplo [macos/i386](https://support.apple.com/en-us/HT208436), en cuyo caso quedará perpetuamente en nivel de soporte 4.
 - Es posible que estas arquitecturas solo soporten `--emit` asm y no puedan emitir archivos.
 
 ## Amigable con los desarrolladores de paquetes

--- a/content/learn/overview.fa.md
+++ b/content/learn/overview.fa.md
@@ -73,7 +73,7 @@ Runtime در build های دارای ایمنی:
 
 هنگامی که با `-O ReleaseSmall` علامت های اشکال زدایی برداشته می شوند و حالت تک رشته ای ایجاد می شود، Zig فایل اجرایی 9.8 KiB برای هدف x86_64-linux تولید می کند:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 این build در ویندوز حتی کوچک تر است و به 4KB میرسد:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.fa.md
+++ b/content/learn/overview.fa.md
@@ -304,15 +304,15 @@ $ zig build test
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-اکنون آن را برای x86_64-windows، x86_64-macosx و aarch64v8-linux بسازید.:
+اکنون آن را برای x86_64-windows، x86_64-macos و aarch64-linux بسازید.:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -404,7 +404,7 @@ $ ldd hello
 
 این بدان معناست که این قابلیت در هر پلتفرمی در دسترس است. کاربران ویندوز و macOS می توانند کد Zig و C را ایجاد کرده و در مقابل libc، برای هر یک از اهداف ذکر شده در بالا پیوند ایجاد کنند. به طور مشابه می توان کد را برای معماری های دیگر کامپایل کرد:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```

--- a/content/learn/overview.fr.md
+++ b/content/learn/overview.fr.md
@@ -331,15 +331,15 @@ Voici un simple Hello World :
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Maintenant voici comment le compiler pour `x86_64-windows`, `x86_64-macosx`, et `aarch64v8-linux` :
+Maintenant voici comment le compiler pour `x86_64-windows`, `x86_64-macos`, et `aarch64-linux` :
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -434,7 +434,7 @@ Cette fonctionnalité est disponible pour toutes les plateformes.
 Les utilisateurs de Windows et macOS peuvent compiler du code C et Zig, les lier à la libc, pour toutes les cibles listées au-dessus.
 De même, le code peut être compilé pour d'autres architectures :
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
@@ -618,7 +618,7 @@ Il est cependant possible de lier l'application à une libc pour compléter ce q
 - La prise en charge de ces cibles est entièrement expérimentale.
 - LLVM peut avoir ces cibles comme *expérimentales*, ce qui veut dire qu'il est nécessaire d'utiliser les binaires fournis par Zig pour avoir accès à ces cibles, ou compiler soi-même LLVM avec des options spécifiques.
 `zig targets` affichera ces cibles si elles sont disponibles.
-- Ces cibles sont considérées abandonnées par l'organisme officiellement en charge, comme [macosx/i386 (EN)](https://support.apple.com/en-us/HT208436), et dans ce cas ces cibles seront toujours bloquées au niveau 4 de prise en charge.
+- Ces cibles sont considérées abandonnées par l'organisme officiellement en charge, comme [macos/i386 (EN)](https://support.apple.com/en-us/HT208436), et dans ce cas ces cibles seront toujours bloquées au niveau 4 de prise en charge.
 - Zig (via LLVM) permet de générer du code assembleur via `--emit asm` mais pas de fichiers objet.
 
 ## Agréable pour les mainteneurs de paquets

--- a/content/learn/overview.fr.md
+++ b/content/learn/overview.fr.md
@@ -82,7 +82,7 @@ Voici un Hello World :
 
 Quand ce code est compilé avec `-O ReleaseSmall`, les symboles de debug retirés, sur un seul fil d'exécution, cela produit un binaire statique de 9.8 KiB pour la cible x86_64 :
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -91,7 +91,7 @@ $ ldd hello
 
 Le binaire produit pour Windows est encore plus petit, seulement 4096 octets :
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.ja.md
+++ b/content/learn/overview.ja.md
@@ -73,7 +73,7 @@ Zig標準ライブラリはlibcと統合されていますが、libcに依存し
 
 `-O ReleaseSmall`、デバッグシンボル除去、シングルスレッドでコンパイルすると、x86_64-linuxターゲットで9.8 KiBの静的実行ファイルが作成されます：
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 Windowsでのビルドはさらに小さく、4096バイトになります：
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.ja.md
+++ b/content/learn/overview.ja.md
@@ -303,15 +303,15 @@ Zigは[サポート表](#support-table)にあるどのターゲットに対し�
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-あとは、x86_64-windows, x86_64-macosx, aarch64v8-linux用にビルドします：
+あとは、x86_64-windows, x86_64-macos, aarch64-linux用にビルドします：
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -403,7 +403,7 @@ $ ldd hello
 
 つまり、この機能はどのプラットフォームでも利用できるのです。WindowsとmacOSのユーザーは、上記のどのターゲットに対しても、ZigとCのコードをビルドし、libcに対してリンクすることができます。同様に、他のアーキテクチャ用にクロスコンパイルすることも可能です：
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```

--- a/content/learn/overview.ko.md
+++ b/content/learn/overview.ko.md
@@ -303,15 +303,15 @@ Zig는 [지원 목록](#지원-목록)에 있는 타겟 중 [티어 3 지원](#�
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-이제 x86_64-windows, x86_64-macosx, aarch64v8-linux로 빌드하려면:
+이제 x86_64-windows, x86_64-macos, aarch64-linux로 빌드하려면:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -403,7 +403,7 @@ $ ldd hello
 
 이 기능은 어떤 플랫폼에서도 사용 가능합니다. Windows와 macOS 사용자는 위에 나열된 어떤 타겟으로도 C 코드를 빌드하고 libc에 링크할 수 있습니다. 비슷하게 다른 아키텍쳐로의 크로스 컴파일도 가능합니다:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
@@ -571,7 +571,7 @@ Zig는 "지원 티어" 체계를 이용해 다른 타겟에 대한 지원 수준
 
 - 이 타겟들의 지원은 완전히 실험적입니다.
 - LLVM에서도 타겟이 실험적일 수 있는데, 그 경우에는 Zig에서 해당 타겟용 바이너리가 나왔을 때 사용하거나, 특별한 설정 플래그와 함께 LLVM을 소스로 빌드해야 합니다.
-- [macosx/i386](https://support.apple.com/en-us/HT208436)의 경우처럼 타겟에 대한 지원이 공식적으로 중단될 수 있는데, 이 경우 타겟은 영원히 티어 4로 남아있게 됩니다.
+- [macos/i386](https://support.apple.com/en-us/HT208436)의 경우처럼 타겟에 대한 지원이 공식적으로 중단될 수 있는데, 이 경우 타겟은 영원히 티어 4로 남아있게 됩니다.
 - 이 타겟은 `--emit` asm만 지원할 수도 있으며 이 경우 오브젝트 파일은 생성되지 않습니다.
 
 ## 패키지 관리자에게 친숙

--- a/content/learn/overview.ko.md
+++ b/content/learn/overview.ko.md
@@ -73,7 +73,7 @@ Zig 표준 라이브러리는 libc와 연동하지만, 의존하지는 않습니
 
 x86_64-linux 타겟으로 `-O ReleaseSmall`에 디버그 심볼을 제거하고 단일 쓰레드 모드로 컴파일 하면, 정적으로 컴파일된 9.9 KiB의 실행파일이 만들어집니다:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 Windows용 빌드는 더 작아서, 4096 byte입니다:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.pt.md
+++ b/content/learn/overview.pt.md
@@ -303,15 +303,15 @@ Zig pode compilar para qualquer um dos dispositivos listados na [Tabela de Supor
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Você pode compilar para: x86_64-windows, x86_64-macosx, e aarch64v8-linux:
+Você pode compilar para: x86_64-windows, x86_64-macos, e aarch64-linux:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -403,7 +403,7 @@ Neste exemplo, Zig construiu musl libc a partir da fonte e depois ligou-se a ela
 
 Isto significa que esta funcionalidade está disponível em qualquer plataforma. Os usuários de Windows e macOS podem criar códigos Zig e C, e vincular-se a libc, para qualquer uma das plataformas listados acima. Da mesma forma, o código pode ser compilado de forma cruzada para outras arquiteturas:
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
@@ -571,7 +571,7 @@ Zig utiliza um sistema de "tiers" para comunicar o nível de suporte para difere
 
 - O apoio a esses objetivos é inteiramente experimental.
 - LLVM pode ter a paltaforma como experimental, o que significa que você precisa usar binários fornecidos em Zig para que a paltaforma esteja disponível, ou construir LLVM a partir da fonte com bandeiras de configuração especiais.
-- Esta plataforma pode ser considerada depreciada por uma parte oficial, como por exemplo [macosx/i386](https://support.apple.com/en-us/HT208436), neste caso, esta meta permanecerá para sempre presa no Nível 4.
+- Esta plataforma pode ser considerada depreciada por uma parte oficial, como por exemplo [macos/i386](https://support.apple.com/en-us/HT208436), neste caso, esta meta permanecerá para sempre presa no Nível 4.
 - Esta plataforma só pode suportar `--emit` asm e não pode emitir arquivos objeto.
 
 ## Colaboradores de pacotes 

--- a/content/learn/overview.pt.md
+++ b/content/learn/overview.pt.md
@@ -73,7 +73,7 @@ A biblioteca padrão do Zig se integra com a libc, mas não depende dela. Aqui e
 
 Quando compilado com `-O ReleaseSmall`, símbolos de depuração são removidos (stripped), modo de thread única, isto produz um executável estático de 9,8 KiB para a plataforma x86_64-linux:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 No Windows é ainda menor, gerando um binário de 4096 bytes:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.ru.md
+++ b/content/learn/overview.ru.md
@@ -307,16 +307,16 @@ Zig может собирать проекты для любой архитек�
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Теперь, чтобы собрать его для архитектур x86_64-windows, x86_64-macosx и aarch64v8-linux:
+Теперь, чтобы собрать его для архитектур x86_64-windows, x86_64-macos и aarch64-linux:
 
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -411,7 +411,7 @@ $ ldd hello
 Это означает, что данная функциональность доступна на любой платформе. Пользователи Windows и macOS могут собирать код на Zig и C и связывать с стандартной библиотекой C для любой из перечисленных выше архитектур. Аналогично, код может быть кросс–компилирован для других архитектур:
 
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```

--- a/content/learn/overview.ru.md
+++ b/content/learn/overview.ru.md
@@ -74,7 +74,7 @@ Zig использует [неопределённое поведение](https
 При компиляции с параметром `-O ReleaseSmall` для однопоточного режиме с последующей очисткой от отладочных символов получается статический исполняемый файл размером 9.8 КиБ для целевой платформы x86_64-linux:
 
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -83,7 +83,7 @@ $ ldd hello
 
 Файл для Windows весит ещё меньше — 4096 байт:
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.tr.md
+++ b/content/learn/overview.tr.md
@@ -76,7 +76,7 @@ Zig Standart Kütüphanesi, libc ile entegre olur, ancak ona bağımlı değildi
 Bu, `-O ReleaseSmall` ile derlendiğinde, hata ayıklama sembolleri çıkarıldığında, tek iş parçacıklı modda, x86_64-linux hedefi için 9.8 KiB boyutunda bir statik çalıştırılabilir dosya üretir:
 
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -86,7 +86,7 @@ $ ldd hello
 Windows derlemesi daha da küçüktür ve 4096 bayt olur:
 
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe

--- a/content/learn/overview.tr.md
+++ b/content/learn/overview.tr.md
@@ -313,16 +313,16 @@ Zig, [Destek Tablosu'ndaki](#desteklenen-geniş-hedef-aralığı) [3. Kademe Des
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-Şimdi x86_64-windows, x86_64-macosx ve aarch64v8-linux için derlemek için:
+Şimdi x86_64-windows, x86_64-macos ve aarch64-linux için derlemek için:
 
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -418,7 +418,7 @@ Bu örnekte Zig, musl libc'yi kaynaktan oluşturdu ve ardından ona karşı bağ
 Bu, bu işlevin herhangi bir platformda kullanılabilir olduğu anlamına gelir. Windows ve macOS kullanıcıları, yukarıda listelenen hedeflerden herhangi biri için Zig ve C kodunu derleyebilir ve libc'ye bağlayabilir. Benzer şekilde, kod diğer mimariler için çapraz derlenebilir:
 
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```

--- a/content/learn/overview.zh.md
+++ b/content/learn/overview.zh.md
@@ -302,15 +302,15 @@ Zig可以为[支持表](#支持表)中的任何[三级支持](#三级支持)或�
 
 {{< zigdoctest "assets/zig-code/features/4-hello.zig" >}}
 
-现在为 x86_64-windows, x86_64-macosx 和 aarch64v8-linux 构建：
+现在为 x86_64-windows, x86_64-macos 和 aarch64-linux 构建：
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
-$ zig build-exe hello.zig -target x86_64-macosx
+$ zig build-exe hello.zig -target x86_64-macos
 $ file hello
 hello: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
-$ zig build-exe hello.zig -target aarch64v8-linux
+$ zig build-exe hello.zig -target aarch64-linux
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
@@ -402,7 +402,7 @@ $ ldd hello
 
 这意味着这个功能可以在任何平台上使用。Windows和MacOS 用户可以为上面列出的任何目标构建Zig和C代码，并与libc链接。同样的代码也可以为其他架构交叉编译：
 ```
-$ zig build-exe hello.c --library c -target aarch64v8-linux-gnu
+$ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
@@ -570,7 +570,7 @@ Zig 使用“支持等级”系统来描述不同目标的支持程度。需要�
 
 - 对这些目标的支持完全是试验性的。
 - LLVM可能会将目标作为实验性目标，这意味着你需要使用 Zig 提供的二进制文件来使目标可用，或者使用特殊的配置标志从源码构建 LLVM ，如果目标可用，`zig targets` 将显示目标。
-- 这个目标可能会被官方认为是废弃的，比如 [macosx/i386](https://support.apple.com/en-us/HT208436)，在这种情况下，这个目标将永远停留在四级。
+- 这个目标可能会被官方认为是废弃的，比如 [macos/i386](https://support.apple.com/en-us/HT208436)，在这种情况下，这个目标将永远停留在四级。
 - 这个目标可能只支持输出汇编（`--emit asm`），而不支持输出对象文件。
 
 ## 对包维护者友好

--- a/content/learn/overview.zh.md
+++ b/content/learn/overview.zh.md
@@ -73,7 +73,7 @@ Zig标准库里集成了libc，但是不依赖于它：
 
 当使用`-O ReleaseSmall`并移除调试符号，单线程模式构建，可以产生一个以x86_64-linux为目标的 9.8 KiB 的静态可执行文件：
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
 9944 hello
 $ ldd hello
@@ -82,7 +82,7 @@ $ ldd hello
 
 Windows的构建就更小了，仅仅 4096 字节：
 ```
-$ zig build-exe hello.zig -O ReleaseSmall --strip --single-threaded -target x86_64-windows
+$ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
 4096 hello.exe
 $ file hello.exe


### PR DESCRIPTION
Within the master branch, the token of `macosx` has been rename to `macos`, and the token of `aarch64v8` is also.

[Os document](https://ziglang.org/documentation/master/std/#A;std:Target.Os.Tag:~:text=lv2%2C-,macos,-%2C)
[Arch document](https://ziglang.org/documentation/master/std/#A;std:Target.Cpu.Arch:~:text=armeb%2C-,aarch64,-%2C)

The compile options have changed:
https://github.com/ziglang/zig/blob/a72d634b731952ee227d026c27e83c5702dcea4a/src/main.zig#L454
https://github.com/ziglang/zig/blob/a72d634b731952ee227d026c27e83c5702dcea4a/src/main.zig#LL448C72-L448C72
