### PR TITLE
Remove --HEAD from Homebrew install

### DIFF
--- a/content/learn/getting-started.ar.md
+++ b/content/learn/getting-started.ar.md
@@ -68,11 +68,6 @@ choco install zig
 brew install zig
 ```
 
-أحدث نسخة بناء من فرع Git الرئيسي:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.de.md
+++ b/content/learn/getting-started.de.md
@@ -72,11 +72,6 @@ Neuestes Release:
 brew install zig
 ```
 
-Neuester Build des Master-Branch:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.en.md
+++ b/content/learn/getting-started.en.md
@@ -91,11 +91,6 @@ Latest tagged release:
 brew install zig
 ```
 
-Latest build from Git master branch:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.es.md
+++ b/content/learn/getting-started.es.md
@@ -65,11 +65,6 @@ choco install zig
 brew install zig
 ```
 
-Última compilación de la rama master de Git:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.fa.md
+++ b/content/learn/getting-started.fa.md
@@ -84,12 +84,6 @@ choco install zig
 brew install zig
 ```
 
-آخرین انتشار از شاخه **master**:
-
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 
 ```

--- a/content/learn/getting-started.fr.md
+++ b/content/learn/getting-started.fr.md
@@ -69,11 +69,6 @@ Dernière version numérotée :
 brew install zig
 ```
 
-Dernière version depuis le dépôt Git (branche master) :
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.ja.md
+++ b/content/learn/getting-started.ja.md
@@ -72,11 +72,6 @@ choco install zig
 brew install zig
 ```
 
-Git masterブランチからの最新ビルド：
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.ko.md
+++ b/content/learn/getting-started.ko.md
@@ -74,11 +74,6 @@ choco install zig
 brew install zig
 ```
 
-Git master 브랜치에서의 최신 빌드:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.pt.md
+++ b/content/learn/getting-started.pt.md
@@ -70,11 +70,6 @@ choco install zig
 brew install zig
 ```
 
-Última compilação do *master branch* de Git:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.ru.md
+++ b/content/learn/getting-started.ru.md
@@ -73,11 +73,6 @@ choco install zig
 brew install zig
 ```
 
-Последняя ночная сборка с master—ветки:
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig

--- a/content/learn/getting-started.tr.md
+++ b/content/learn/getting-started.tr.md
@@ -80,12 +80,6 @@ En son etiketli sürüm:
 brew install zig
 ```
 
-Git ana dallından en son derleme:
-
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 
 ```

--- a/content/learn/getting-started.zh.md
+++ b/content/learn/getting-started.zh.md
@@ -71,11 +71,6 @@ choco install zig
 brew install zig
 ```
 
-从 github master 分支获取的最新构建：
-```
-brew install zig --HEAD
-```
-
 **MacPorts**
 ```
 port install zig


### PR DESCRIPTION
As per this [comment](https://github.com/Homebrew/homebrew-core/issues/134298#issuecomment-1606271980) regarding the "installing `zig --HEAD` from homebrew" situation, I removed all instances I found of `brew install zig --HEAD` from the "Getting Started" documentation pages.