### PR TITLE
fix logo margin

### DIFF
--- a/themes/ziglang-original/assets/css/style.css
+++ b/themes/ziglang-original/assets/css/style.css
@@ -217,7 +217,7 @@ img {
   height: 90px;
   display: block;
   padding: 0;
-  margin: 0;
+  margin: 10px 0;
 }
 
 h1:lang(ja), h2:lang(ja), h3:lang(ja), h4:lang(ja) {


### PR DESCRIPTION



https://github.com/ziglang/www.ziglang.org/assets/15584994/178853c4-4404-4b4c-8375-b8ae35c5b3fe

fixes the page jumping around when changing system color schemes