### PR TITLE
Add a link to Exercism track

### DIFF
--- a/content/learn/_index.ar.md
+++ b/content/learn/_index.ar.md
@@ -35,6 +35,8 @@ layout: single
 مقدمة منظمة لـZig بواسطة [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://github.com/ratfactor/ziglings)
 تعلم Zig عن طريق تصحيح برامج تالفة بسيطة.
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## فيديوهات وتدوينات متعلقة
 - [الطريق إلى Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [فيديو]  

--- a/content/learn/_index.de.md
+++ b/content/learn/_index.de.md
@@ -34,6 +34,8 @@ Wenn du bereit bist, in Zig zu programmieren, hilft diese Anleitung bei der Einr
 - [Zig Learn](https://ziglearn.org)  
 - Eine strukturierte Einführung in Zig von [Sobeston](https://github.com/sobeston).  
 - Lerne Zig beim Reparieren kleiner Programme mit [ziglings](https://github.com/ratfactor/ziglings).
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## Relevante Videos und Blogposts
 - [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  

--- a/content/learn/_index.en.md
+++ b/content/learn/_index.en.md
@@ -35,6 +35,8 @@ If you're ready to start programming in Zig, this guide will help you setup your
 A structured introduction to Zig by [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://github.com/ratfactor/ziglings)  
 Learn Zig by fixing tiny broken programs.
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## Relevant videos and blog posts
 - [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  

--- a/content/learn/_index.es.md
+++ b/content/learn/_index.es.md
@@ -34,6 +34,8 @@ Si estás listo para comenzar a programar con Zig, esta guía te ayudará a pone
 Una introducción estructurada a Zig por [Sobeston](https://github.com/sobeston).
 - [ziglings](https://github.com/ratfactor/ziglings).  
 Aprende Zig corrigiendo pequeños errores en programas
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## Videos relevantes y artículos de blog
 - [La ruta a Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  

--- a/content/learn/_index.fa.md
+++ b/content/learn/_index.fa.md
@@ -39,6 +39,8 @@ layout: single
     مقدمه‌ای ساختارمند برای زیگ توسط [Sobeston](https://github.com/sobeston).
 -   [Ziglings](https://github.com/ratfactor/ziglings)  
     با تعمیر برنامه های کوچک خراب، زیگ را بیاموزید.
+-   [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## فیلم ها و پست های وبلاگ مربوطه
 

--- a/content/learn/_index.fr.md
+++ b/content/learn/_index.fr.md
@@ -34,6 +34,8 @@ Si vous êtes déjà prêt à développer en Zig, ce guide vous aidera à config
 - [Zig Learn (EN)](https://ziglearn.org)
 - Une introduction structurée à Zig par [Sobeston (EN)](https://github.com/sobeston).  
 - Apprenez à corriger les petits programmes avec Zig [ziglings](https://github.com/ratfactor/ziglings).
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## Vidéos et articles de blog
 - [Road to Zig 1.0 (EN)](https://www.youtube.com/watch?v=Gv2I7qTux7g) [vidéo]

--- a/content/learn/_index.it.md
+++ b/content/learn/_index.it.md
@@ -35,6 +35,8 @@ Se siete pronti ad iniziare a programmare in Zig, questa guida vi aiutera' a pre
 - [Zig Learn](https://ziglearn.org)  
 - A structured introduction to Zig by [Sobeston](https://github.com/sobeston).
 - Impara Zig su come riparare piccoli programmi danneggiati con [ziglings](https://github.com/ratfactor/ziglings).
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## Relevant videos and blog posts
 - [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  

--- a/content/learn/_index.ja.md
+++ b/content/learn/_index.ja.md
@@ -35,6 +35,8 @@ Zigでプログラミングを始める準備ができたら、このガイド�
 [Sobeston](https://github.com/sobeston)によるZigの構造的な紹介。
 - [Ziglings](https://github.com/ratfactor/ziglings)
 小さな壊れたプログラムを修正することでZigを学ぶ。
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Zigで演習を解いて、メンターの批評を受けて学ぶ。
 
 ## 関連する動画やブログ記事
 - [Zig 1.0への道のり](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]

--- a/content/learn/_index.ko.md
+++ b/content/learn/_index.ko.md
@@ -35,6 +35,8 @@ Zig로 프로그래밍을 할 준비가 되셨다면, 아래 가이드는 여러
 [Sobeston](https://github.com/sobeston)님이 직접 작성한, 체계적인 Zig 프로그래밍 언어 강좌입니다.
 - [Ziglings](https://github.com/ratfactor/ziglings)  
 제대로 작동하지 않는 프로그램들을 고치면서 Zig를 배워보세요.
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## 관련 영상과 블로그 글
 - [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [동영상]  

--- a/content/learn/_index.pt.md
+++ b/content/learn/_index.pt.md
@@ -34,6 +34,8 @@ Se você estiver pronto para começar a programar em Zig, este guia o ajudará a
 - [Zig Learn](https://ziglearn.org)  
 - Uma introdução estruturada ao Zig, por [Sobeston](https://github.com/sobeston).
 - Aprenda Zig enquanto conserta pequenos programas quebrados com [ziglings](https://github.com/ratfactor/ziglings).
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## Vídeos e posts relevantes no blog
 - [Zig a caminho do 1.0 (inglês)](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  

--- a/content/learn/_index.ru.md
+++ b/content/learn/_index.ru.md
@@ -34,6 +34,8 @@ layout: single
 - [Zig Learn](https://ziglearn.org)  
 Структурированное введение в Zig от [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://github.com/ratfactor/ziglings)  
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 Изучайте Zig, исправляя маленькие сломанные программы.
 
 ## Связанные видео и блоги

--- a/content/learn/_index.tr.md
+++ b/content/learn/_index.tr.md
@@ -39,6 +39,8 @@ Eğer Zig'de programlamaya hazırsanız, bu rehber size ortamınızı kurmanızd
   [Sobeston](https://github.com/sobeston) tarafından yapılandırılmış Zig'e yönelik bir giriş.
 - [Ziglings](https://github.com/ratfactor/ziglings)  
   Programların küçük hatalarını düzelterek Zig öğrenin.
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## İlgili videolar ve blog yazıları
 

--- a/content/learn/_index.zh.md
+++ b/content/learn/_index.zh.md
@@ -35,6 +35,8 @@ layout: single
 Zig 的结构化介绍，由 [Sobeston](https://github.com/sobeston) 编写
 - [Zig 小练习](https://github.com/ratfactor/ziglings)
 通过修补与调试一系列带有故障的小程序来学习 Zig
+- [Zig on Exercism](https://exercism.org/tracks/zig)
+Solve coding exercises and get mentored to develop fluency in Zig.
 
 ## 相关视频和博客文章
 - [Zig 1.0 之路（英文）](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]


### PR DESCRIPTION
Exercism is a not-for-profit organisation registered in the UK. The Zig track was soft-launched earlier this year, and is now stable and growing with more than 1000 students!

~~P.S. The site is only available in English like Ziglearn and Ziglings, but should I add it to pages for other languages I can write?~~ Yes

P.P.S. if anyone arrives here interested in contributing to Zig on Exercism, go to https://github.com/exercism/zig