### PR TITLE
Fix typos and small mistakes in 0.11.0 release notes

### DIFF
--- a/content/download/0.11.0/release-notes.html
+++ b/content/download/0.11.0/release-notes.html
@@ -1829,11 +1829,11 @@ All 1 tests passed.
     <code><span class="line"><span class="tok-builtin">@memset</span></span></code> to make them more useful.
     </p>
     <p>
-    <code><span class="line"><span class="tok-builtin">@memcpy</span></span></code> now takes two parameters. The first is the destination, and must
-    be a mutable slice of any any element type. The second parameter is the source value, which may
-    be either a slice of the element type (in which case it must have the same length) or a
-    many-pointer to it (in which case it is implicitly sliced to the same length). The builtin
-    copies values from the source address to the destination address.
+    <code><span class="line"><span class="tok-builtin">@memcpy</span></span></code> now takes two parameters. The first is the destination, and the
+    second is the source. The builtin copies values from the source address to the destination
+    address. Both parameters may be a slice or many-pointer of any element type; the destination
+    parameter must be mutable in either case. At least one of the parameters must be a slice; if
+    both parameters are a slice, then the two slices must be of equal length.
     </p>
     <p>
     The source and destination memory must not overlap (overlap is considered safety-checked
@@ -2756,7 +2756,7 @@ All 1 tests passed.
     As such, comparisons of this form are now allowed. However, since these comparisons are
     tautological, they do not cause any runtime checks: instead, the result is comptime-known based
     on the type. For instance, <code><span class="line">my_u8 == <span class="tok-number">500</span></span></code> is comptime-known
-    <code><span class="line"><span class="tok-null">true</span></span></code>, even if <code><span class="line">my_u8</span></code> is not itself comptime-known.
+    <code><span class="line"><span class="tok-null">false</span></span></code>, even if <code><span class="line">my_u8</span></code> is not itself comptime-known.
     </p>
     <figure><figcaption class="zig-cap"><cite class="file">tautological_compare_comptime.zig</cite></figcaption><pre><code><span class="line"><span class="tok-kw">test</span> <span class="tok-str">&quot;tautological comparisons are comptime-known&quot;</span> {</span>
 <span class="line">    <span class="tok-kw">var</span> x: <span class="tok-type">u8</span> = <span class="tok-number">123</span>;</span>
@@ -3677,7 +3677,7 @@ target-specific runtime calls and returns to be constructed.</p>
 <p>In order to print a stack trace, the panic (or segfault) handler needs to unwind the stack, by traversing back through the stack frames starting at the crash site. Up until now, this was done strictly by utilizing the <a href="https://en.wikipedia.org/wiki/Call_stack#Stack_and_frame_pointers">frame pointer</a>. This method of stack unwinding works assuming that a frame pointer is available, which isn't the case if the code is compiled without one - ie. if <code>-fomit-frame-pointer</code>was used. </p>
 <p>It can be beneficial for performance reasons to not use a frame pointer, since this frees up an additional register, so some software maintainers may choose to ship libraries compiled without it. One of the motivating reasons for this change was solving a bug where unwinding a stack trace that started in Ubuntu's libc wasn't working - and indeed it is compiled with <code>-fomit-frame-pointer</code>.</p>
 <p>Since <a href="https://github.com/ziglang/zig/pull/15823">#15823</a> was merged, the <a href="#Standard-Library">Standard Library</a> stack unwinder (<code>std.debug.StackIterator</code>) now supports unwinding stacks using both DWARF unwind tables, and <a href="#MachO">MachO</a> compact unwind information. These unwind tables encode how to unwind all the register state and recover the return address for any location in the program. </p>
-<p>In order to save space, DWARF unwind tables aren't program-sized lookup tables, but instead sets of opcodes which run on a virtual machine inside the unwinder to build the lookup table dynmamically. Additionally, these tables can define register values in terms of DWARF expressions, which is a separate stack-machine based bytecode. This is all supported in the new unwinder.</p>
+<p>In order to save space, DWARF unwind tables aren't program-sized lookup tables, but instead sets of opcodes which run on a virtual machine inside the unwinder to build the lookup table dynamically. Additionally, these tables can define register values in terms of DWARF expressions, which is a separate stack-machine based bytecode. This is all supported in the new unwinder.</p>
 <p>As an example of how this improves stack trace output, consider the following zig program and C library (which will be built with <code>-fomit-frame-pointer</code>):</p>
 <figure><figcaption class="zig-cap"><cite class="file">main.zig</cite></figcaption><pre><code><span class="line"><span class="tok-kw">const</span> std = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;std&quot;</span>);</span>
 <span class="line"></span>

--- a/content/download/0.11.0/release-notes.html
+++ b/content/download/0.11.0/release-notes.html
@@ -1252,7 +1252,7 @@ $ <kbd>clang-offload-bundler -type=o -bundle-align=4096 \
     <a href="https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet">Microsoft dropped LTS support for 8.1 in January</a>.
     Patches to Zig supporting for older versions of Windows are still accepted into
     the codebase, but they are not regularly tested, not part of the
-    part of <a href="#Bug-Stability-Program">Bug Stability Program</a>, and not covered by the <a href="#Tier-System">Tier System</a>.
+    <a href="#Bug-Stability-Program">Bug Stability Program</a>, and not covered by the <a href="#Tier-System">Tier System</a>.
     </p>
   <ul>
     <li>Fix _tls_index not being defined if libc wasn't linked, and fix x86 name mangling.</li>
@@ -2986,7 +2986,7 @@ All 2 tests passed.
     <p>
     0.10 had some arbitrary restrictions on the types of function parameters and their return types:
     they were not permitted to be <code><span class="line"><span class="tok-builtin">@TypeOf</span>(<span class="tok-null">null</span>)</span></code> or
-    <code><span class="line"><span class="tok-builtin">@TypeOf</span>(<span class="tok-null">undefined</span>)</span></code>. While these are types are rarely useful in this
+    <code><span class="line"><span class="tok-builtin">@TypeOf</span>(<span class="tok-null">undefined</span>)</span></code>. While these types are rarely useful in this
     context, they are still completely normal comptime-only types, so this restriction on their
     usage was needless. As such, they are now allowed as parameter and return types.
     </p>

--- a/content/download/0.11.0/release-notes.html
+++ b/content/download/0.11.0/release-notes.html
@@ -5374,7 +5374,6 @@ Hello World!
 <li>Bas Westerbaan</li>
 <li>Carl Åstholm</li>
 <li>Emile Badenhorst</li>
-<li>Felix "xq" Queißner</li>
 <li>Igor Anić</li>
 <li>Lee Cannon</li>
 <li>Matt Knight</li>
@@ -5401,7 +5400,6 @@ Hello World!
 <li>Edoardo Vacchi</li>
 <li>Emile Badenhorst</li>
 <li>Eric Milliken</li>
-<li>Felix (xq) Queißner</li>
 <li>Ganesan Rajagopal</li>
 <li>Garrett</li>
 <li>Gaëtan S</li>
@@ -5455,7 +5453,6 @@ Hello World!
 <li>Eric Rowley</li>
 <li>Evan Typanski</li>
 <li>Fabio Arnold</li>
-<li>Felix Queißner</li>
 <li>Frechdachs</li>
 <li>George  Zhao</li>
 <li>Gregory Oakes</li>

--- a/src/download/0.11.0/release-notes.html
+++ b/src/download/0.11.0/release-notes.html
@@ -994,7 +994,7 @@ $ clang-offload-bundler -type=o -bundle-align=4096 \
     <a href="https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet">Microsoft dropped LTS support for 8.1 in January</a>.
     Patches to Zig supporting for older versions of Windows are still accepted into
     the codebase, but they are not regularly tested, not part of the
-    part of {#link|Bug Stability Program#}, and not covered by the {#link|Tier System#}.
+    {#link|Bug Stability Program#}, and not covered by the {#link|Tier System#}.
     </p>
   <ul>
     <li>Fix _tls_index not being defined if libc wasn't linked, and fix x86 name mangling.</li>
@@ -2617,7 +2617,7 @@ fn g(u: *U2) void {
     <p>
     0.10 had some arbitrary restrictions on the types of function parameters and their return types:
     they were not permitted to be {#syntax#}@TypeOf(null){#endsyntax#} or
-    {#syntax#}@TypeOf(undefined){#endsyntax#}. While these are types are rarely useful in this
+    {#syntax#}@TypeOf(undefined){#endsyntax#}. While these types are rarely useful in this
     context, they are still completely normal comptime-only types, so this restriction on their
     usage was needless. As such, they are now allowed as parameter and return types.
     </p>

--- a/src/download/0.11.0/release-notes.html
+++ b/src/download/0.11.0/release-notes.html
@@ -4905,7 +4905,6 @@ Hello World!
 <li>Bas Westerbaan</li>
 <li>Carl Åstholm</li>
 <li>Emile Badenhorst</li>
-<li>Felix "xq" Queißner</li>
 <li>Igor Anić</li>
 <li>Lee Cannon</li>
 <li>Matt Knight</li>
@@ -4932,7 +4931,6 @@ Hello World!
 <li>Edoardo Vacchi</li>
 <li>Emile Badenhorst</li>
 <li>Eric Milliken</li>
-<li>Felix (xq) Queißner</li>
 <li>Ganesan Rajagopal</li>
 <li>Garrett</li>
 <li>Gaëtan S</li>
@@ -4986,7 +4984,6 @@ Hello World!
 <li>Eric Rowley</li>
 <li>Evan Typanski</li>
 <li>Fabio Arnold</li>
-<li>Felix Queißner</li>
 <li>Frechdachs</li>
 <li>George  Zhao</li>
 <li>Gregory Oakes</li>

--- a/src/download/0.11.0/release-notes.html
+++ b/src/download/0.11.0/release-notes.html
@@ -1544,11 +1544,11 @@ test "pointer capture from array" {
     {#syntax#}@memset{#endsyntax#} to make them more useful.
     </p>
     <p>
-    {#syntax#}@memcpy{#endsyntax#} now takes two parameters. The first is the destination, and must
-    be a mutable slice of any any element type. The second parameter is the source value, which may
-    be either a slice of the element type (in which case it must have the same length) or a
-    many-pointer to it (in which case it is implicitly sliced to the same length). The builtin
-    copies values from the source address to the destination address.
+    {#syntax#}@memcpy{#endsyntax#} now takes two parameters. The first is the destination, and the
+    second is the source. The builtin copies values from the source address to the destination
+    address. Both parameters may be a slice or many-pointer of any element type; the destination
+    parameter must be mutable in either case. At least one of the parameters must be a slice; if
+    both parameters are a slice, then the two slices must be of equal length.
     </p>
     <p>
     The source and destination memory must not overlap (overlap is considered safety-checked
@@ -2397,7 +2397,7 @@ const Foo = struct {
     As such, comparisons of this form are now allowed. However, since these comparisons are
     tautological, they do not cause any runtime checks: instead, the result is comptime-known based
     on the type. For instance, {#syntax#}my_u8 == 500{#endsyntax#} is comptime-known
-    {#syntax#}true{#endsyntax#}, even if {#syntax#}my_u8{#endsyntax#} is not itself comptime-known.
+    {#syntax#}false{#endsyntax#}, even if {#syntax#}my_u8{#endsyntax#} is not itself comptime-known.
     </p>
     {#code_begin|test|tautological_compare_comptime#}
 test "tautological comparisons are comptime-known" {
@@ -3256,7 +3256,7 @@ if (allocator.resize(old_memory, new_capacity)) {
 <p>In order to print a stack trace, the panic (or segfault) handler needs to unwind the stack, by traversing back through the stack frames starting at the crash site. Up until now, this was done strictly by utilizing the <a href="https://en.wikipedia.org/wiki/Call_stack#Stack_and_frame_pointers">frame pointer</a>. This method of stack unwinding works assuming that a frame pointer is available, which isn't the case if the code is compiled without one - ie. if <code>-fomit-frame-pointer</code>was used. </p>
 <p>It can be beneficial for performance reasons to not use a frame pointer, since this frees up an additional register, so some software maintainers may choose to ship libraries compiled without it. One of the motivating reasons for this change was solving a bug where unwinding a stack trace that started in Ubuntu's libc wasn't working - and indeed it is compiled with <code>-fomit-frame-pointer</code>.</p>
 <p>Since <a href="https://github.com/ziglang/zig/pull/15823">#15823</a> was merged, the {#link|Standard Library#} stack unwinder (<code>std.debug.StackIterator</code>) now supports unwinding stacks using both DWARF unwind tables, and {#link|MachO#} compact unwind information. These unwind tables encode how to unwind all the register state and recover the return address for any location in the program. </p>
-<p>In order to save space, DWARF unwind tables aren't program-sized lookup tables, but instead sets of opcodes which run on a virtual machine inside the unwinder to build the lookup table dynmamically. Additionally, these tables can define register values in terms of DWARF expressions, which is a separate stack-machine based bytecode. This is all supported in the new unwinder.</p>
+<p>In order to save space, DWARF unwind tables aren't program-sized lookup tables, but instead sets of opcodes which run on a virtual machine inside the unwinder to build the lookup table dynamically. Additionally, these tables can define register values in terms of DWARF expressions, which is a separate stack-machine based bytecode. This is all supported in the new unwinder.</p>
 <p>As an example of how this improves stack trace output, consider the following zig program and C library (which will be built with <code>-fomit-frame-pointer</code>):</p>
 {#code_begin|syntax|main#}
 const std = @import("std");


### PR DESCRIPTION
- Fixes two small typos: 
  - `dynmamically` -> `dynamically`
  - `my_u8 == 500 is comptime-known true` -> `my_u8 == 500 is comptime-known false`    (`u8` range cannot reach `500` as a value)
- Fixes notes about `@memcpy` to reflect that the destination may also be a many-pointer, as long as _one_ of the parameters is a slice.
- Condenses the many references to @MasterQ32 in contributor list into one :3
- Removes erroneously repeated words:
  - `not part of the part of` -> `not part of the`
  - `these are types are` -> `these types are`