### PR TITLE
seperate download table into sections by OS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,7 +26,7 @@ downloads_release_order = [
   "0.2.0",
   "0.1.1",
 ]
-download_section_order = ["src", "windows", "macos", "linux"]
+download_section_order = ["src", "windows", "macos", "linux", "freebsd"]
   [params.download_section]
     [params.download_section.src]
       title = "download-source"
@@ -44,6 +44,10 @@ download_section_order = ["src", "windows", "macos", "linux"]
       title = "Linux"
       release_suffix = "-linux"
       rows = ["x86_64", "i386", "x86", "aarch64", "armv6kz", "armv7a", "riscv64", "powerpc64le", "powerpc"]
+    [params.download_section.freebsd]
+      title = "FreeBSD"
+      release_suffix = "-freebsd"
+      rows = ["x86_64"]
 
 [markup.goldmark.renderer]
 unsafe = true

--- a/config.toml
+++ b/config.toml
@@ -26,26 +26,24 @@ downloads_release_order = [
   "0.2.0",
   "0.1.1",
 ]
-downloads_arch_order = [
-  "src",
-  "bootstrap",
-  "x86_64-windows",
-  "x86-windows",
-  "i386-windows",
-  "aarch64-windows",
-  "aarch64-macos",
-  "x86_64-macos",
-  "x86_64-linux",
-  "i386-linux",
-  "x86-linux",
-  "aarch64-linux",
-  "armv6kz-linux",
-  "armv7a-linux",
-  "riscv64-linux",
-  "powerpc64le-linux",
-  "powerpc-linux",
-  "x86_64-freebsd",
-]
+download_section_order = ["src", "windows", "macos", "linux"]
+  [params.download_section]
+    [params.download_section.src]
+      title = "download-source"
+      release_suffix = ""
+      rows = ["src", "bootstrap"]
+    [params.download_section.windows]
+      title = "Windows"
+      release_suffix = "-windows"
+      rows = ["x86_64", "x86", "i386", "aarch64"]
+    [params.download_section.macos]
+      title = "macOS"
+      release_suffix = "-macos"
+      rows = ["aarch64","x86_64"]
+    [params.download_section.linux]
+      title = "Linux"
+      release_suffix = "-linux"
+      rows = ["x86_64", "i386", "x86", "aarch64", "armv6kz", "armv7a", "riscv64", "powerpc64le", "powerpc"]
 
 [markup.goldmark.renderer]
 unsafe = true

--- a/themes/ziglang-original/assets/css/style.css
+++ b/themes/ziglang-original/assets/css/style.css
@@ -91,7 +91,7 @@ td {
   font-size: 0.96em;
 }
 
-th {
+th, .last-row-in-section {
   border-bottom: 2px solid #f2f3f3;
 }
 
@@ -256,7 +256,7 @@ h1:lang(ja), h2:lang(ja), h3:lang(ja), h4:lang(ja) {
     color: #ffffff;
   }
 
-  table, th, td {
+  table, th, td, .last-row-in-section {
     border-color: grey;
   }
 

--- a/themes/ziglang-original/assets/css/style.css
+++ b/themes/ziglang-original/assets/css/style.css
@@ -95,7 +95,7 @@ th, .last-row-in-section {
   border-bottom: 2px solid #f2f3f3;
 }
 
-tr:nth-child(even) {
+tr:nth-child(even)>td {
   background: #f2f3f3;
 }
 
@@ -260,7 +260,7 @@ h1:lang(ja), h2:lang(ja), h3:lang(ja), h4:lang(ja) {
     border-color: grey;
   }
 
-  tr:nth-child(even) {
+  tr:nth-child(even)>td {
     background: #1e1e1e;
   }
 

--- a/themes/ziglang-original/i18n/en.toml
+++ b/themes/ziglang-original/i18n/en.toml
@@ -34,6 +34,12 @@ other = "Binary"
 [download-documentation]
 other = "<a href=\"{{ . }}\">Language Reference</a>"
 
+[download-os]
+other = "OS"
+
+[download-arch]
+other = "Arch"
+
 [download-filename]
 other = "Filename"
 

--- a/themes/ziglang-original/layouts/_default/downloads.html
+++ b/themes/ziglang-original/layouts/_default/downloads.html
@@ -79,7 +79,6 @@
                 {{ end }}
               </tr>
               {{ end }}
-            <tr>
             {{ end }}
           </tbody>
         </table>

--- a/themes/ziglang-original/layouts/_default/downloads.html
+++ b/themes/ziglang-original/layouts/_default/downloads.html
@@ -44,17 +44,25 @@
           <tbody>
             {{ range $section_name := $.Site.Params.download_section_order }}
             {{ $section := index $.Site.Params.download_section $section_name }}
+              {{ $rows := slice }}
               {{ range $row_index, $row_name := $section.rows }}
+                {{ $target_name := printf "%s%s" $row_name $section.release_suffix }}
+                {{ with index $release $target_name }}
+                  {{ $rows = $rows | append $row_name }}
+                {{ end }}
+              {{ end }}
+
+              {{ range $row_index, $row_name := $rows }}
               <tr>
                 {{ if eq $row_index 0 }}
                   {{ $title := $section.title }}
                   {{ if eq $section_name "src" }}
                     {{ $title = i18n $title }}
                   {{ end }}
-                  <th rowspan="{{ len $section.rows }}">{{ $title }}</th>
+                  <th rowspan="{{ len $rows }}">{{ $title }}</th>
                 {{ end }}
                 {{ $td_class := "" }}
-                {{ if eq $row_index (sub (len $section.rows) 1) }}
+                {{ if eq $row_index (sub (len $rows) 1) }}
                   {{ $td_class = "last-row-in-section" }}
                 {{ end }}
                 {{ $arch := $row_name }}

--- a/themes/ziglang-original/layouts/_default/downloads.html
+++ b/themes/ziglang-original/layouts/_default/downloads.html
@@ -27,36 +27,51 @@
 
         <table>
           <colgroup>
-            <col width="40%">
             <col width="10%">
+            <col width="10%">
+            <col width="40%">
             <col width="10%">
           </colgroup>
           <thead>
             <tr>
+              <th>{{ i18n "download-os" }}</th>
+              <th>{{ i18n "download-arch" }}</th>
               <th>{{ i18n "download-filename" }}</th>
               <th>{{ i18n "download-sig" }}</th>
-              <th>{{ i18n "download-kind" }}</th>
               <th>{{ i18n "download-size" }}</th>
             </tr>
           </thead>
           <tbody>
-            {{ range $target_name := $.Site.Params.downloads_arch_order}}
-              {{ with index $release $target_name}}
-                <tr>
-                  <td><a href="{{ index . "tarball"}}">{{ path.Base (index . "tarball")}}</a></td>
-                  <td><a href="{{ index . "tarball"}}.minisig">minisig</a></td>
-                  <td>
-                  {{ if eq $target_name "src"}}
-                    {{ i18n "download-source" }}
-                  {{ else if eq $target_name "bootstrap" }}
-                    {{ i18n "download-source" }}
-                  {{ else }}
-                    {{ i18n "download-binary" }}
+            {{ range $section_name := $.Site.Params.download_section_order }}
+            {{ $section := index $.Site.Params.download_section $section_name }}
+              {{ range $row_index, $row_name := $section.rows }}
+              <tr>
+                {{ if eq $row_index 0 }}
+                  {{ $title := $section.title }}
+                  {{ if eq $section_name "src" }}
+                    {{ $title = i18n $title }}
                   {{ end }}
-                  </td>
-                  <td>{{ lang.NumFmt 1 (div (int (index . "size")) 1048576.0)}}MiB</td>
-                </tr>
-              {{end}}
+                  <th rowspan="{{ len $section.rows }}">{{ $title }}</th>
+                {{ end }}
+                {{ $td_class := "" }}
+                {{ if eq $row_index (sub (len $section.rows) 1) }}
+                  {{ $td_class = "last-row-in-section" }}
+                {{ end }}
+                {{ $arch := $row_name }}
+                {{ if eq $section_name "src" }}
+                  {{ $arch = "" }}
+                {{ end }}
+
+                {{ $target_name := printf "%s%s" $row_name $section.release_suffix }}
+                {{ with index $release $target_name}}
+                  <td class="{{$td_class}}">{{ $arch }}</td>
+                  <td class="{{$td_class}}"><a href="{{ index . "tarball"}}">{{ path.Base (index . "tarball")}}</a></td>
+                  <td class="{{$td_class}}"><a href="{{ index . "tarball"}}.minisig">minisig</a></td>
+                  <td class="{{$td_class}}">{{ lang.NumFmt 1 (div (int (index . "size")) 1048576.0)}}MiB</td>
+                {{ end }}
+              </tr>
+              {{ end }}
+            <tr>
             {{ end }}
           </tbody>
         </table>


### PR DESCRIPTION
Here's a preview of the new table:

![image](https://github.com/ziglang/www.ziglang.org/assets/304904/049336a5-3520-43a3-9a03-ba3c556e94a9)

A cool follow up change...add svg icons to each OS.

NOTE: this removes the "Kind" column which previously showed whether the archive was a source or binary download.  With this being removed we could also remove the `download-kind` and `download-binary` i18n entries.  However, we're still using the `download-source` entry for the title of the Source section.
