### PR TITLE
remove "Source" text from OS column

### DIFF
--- a/themes/ziglang-original/layouts/_default/downloads.html
+++ b/themes/ziglang-original/layouts/_default/downloads.html
@@ -54,16 +54,16 @@
 
               {{ range $row_index, $row_name := $rows }}
               <tr>
-                {{ if eq $row_index 0 }}
-                  {{ $title := $section.title }}
-                  {{ if eq $section_name "src" }}
-                    {{ $title = i18n $title }}
-                  {{ end }}
-                  <th rowspan="{{ len $rows }}">{{ $title }}</th>
-                {{ end }}
                 {{ $td_class := "" }}
                 {{ if eq $row_index (sub (len $rows) 1) }}
                   {{ $td_class = "last-row-in-section" }}
+                {{ end }}
+                {{ if eq $section_name "src" }}
+                  <td class="{{$td_class}}"></td>
+                {{ else }}
+                  {{ if eq $row_index 0 }}
+                    <th rowspan="{{ len $rows }}">{{ $section.title }}</th>
+                  {{ end }}
                 {{ end }}
                 {{ $arch := $row_name }}
                 {{ if eq $section_name "src" }}

--- a/themes/ziglang-original/layouts/_default/downloads.html
+++ b/themes/ziglang-original/layouts/_default/downloads.html
@@ -58,10 +58,12 @@
                 {{ if eq $row_index (sub (len $rows) 1) }}
                   {{ $td_class = "last-row-in-section" }}
                 {{ end }}
-                {{ if eq $section_name "src" }}
-                  <td class="{{$td_class}}"></td>
-                {{ else }}
-                  {{ if eq $row_index 0 }}
+                {{ if eq $row_index 0 }}
+                  {{ if eq $section_name "src" }}
+                    <th class="{{$td_class}}" style="text-align:center" colspan="2" rowspan="{{ len $rows }}">
+                      {{ i18n $section.title }}
+                    </th>
+                  {{ else }}
                     <th rowspan="{{ len $rows }}">{{ $section.title }}</th>
                   {{ end }}
                 {{ end }}
@@ -72,7 +74,9 @@
 
                 {{ $target_name := printf "%s%s" $row_name $section.release_suffix }}
                 {{ with index $release $target_name}}
-                  <td class="{{$td_class}}">{{ $arch }}</td>
+                  {{ if ne $section_name "src" }}
+                    <td class="{{$td_class}}">{{ $arch }}</td>
+                  {{ end }}
                   <td class="{{$td_class}}"><a href="{{ index . "tarball"}}">{{ path.Base (index . "tarball")}}</a></td>
                   <td class="{{$td_class}}"><a href="{{ index . "tarball"}}.minisig">minisig</a></td>
                   <td class="{{$td_class}}">{{ lang.NumFmt 1 (div (int (index . "size")) 1048576.0)}}MiB</td>


### PR DESCRIPTION
Removes "Source" from the OS column for the src/bootstrap tarballs.

## CURRENT

![image](https://github.com/ziglang/www.ziglang.org/assets/304904/e54bafbd-051f-4491-b57e-a5bae8ff1faf)

## NEW

![image](https://github.com/ziglang/www.ziglang.org/assets/304904/57f59c88-c0d0-4011-b6ae-da896466282b)
