### PR TITLE
Add Russian translation for new i18n entries `download-os` and `download-arch`

### DIFF
--- a/themes/ziglang-original/i18n/ru.toml
+++ b/themes/ziglang-original/i18n/ru.toml
@@ -34,6 +34,12 @@ other = "Архив с двоичными файлами"
 [download-documentation]
 other = "<a href=\"{{ . }}\">Документация языка</a>"
 
+[download-os]
+other = "Операционная система"
+
+[download-arch]
+other = "Архитектура"
+
 [download-filename]
 other = "Название файла"
 
@@ -50,7 +56,7 @@ other = "<a href=\"{{ . }}\">Примечания к выпуску</a>"
 other = "Размер"
 
 [download-source]
-other = "Архив с исходным кодом"
+other = "Исходный код"
 
 [download-stdlib-docs]
 other = "<a href=\"{{ . }}\">Документация стандартной библиотеки</a> (экспериментальная)"


### PR DESCRIPTION
Followup to https://github.com/ziglang/www.ziglang.org/pull/303 and https://github.com/ziglang/www.ziglang.org/commit/17a8120cc9fbf89ae99192c013f6f99936b335d3 .