### PR TITLE
Add SVG favicon

### DIFF
--- a/content/documentation/0.5.0/index.html
+++ b/content/documentation/0.5.0/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>Documentation - The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style type="text/css">
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.1.1/release-notes.html
+++ b/content/download/0.1.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.1.1 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       #contents {
         max-width: 50em;

--- a/content/download/0.10.0/release-notes.html
+++ b/content/download/0.10.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.10.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/content/download/0.10.1/release-notes.html
+++ b/content/download/0.10.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.10.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/content/download/0.11.0/release-notes.html
+++ b/content/download/0.11.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.11.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/content/download/0.2.0/release-notes.html
+++ b/content/download/0.2.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.2.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
 .hljs{display:block;overflow-x:auto;padding:0.5em;color:#333;background:#f8f8f8}.hljs-comment,.hljs-quote{color:#998;font-style:italic}.hljs-keyword,.hljs-selector-tag,.hljs-subst{color:#333;font-weight:bold}.hljs-number,.hljs-literal,.hljs-variable,.hljs-template-variable,.hljs-tag .hljs-attr{color:#008080}.hljs-string,.hljs-doctag{color:#d14}.hljs-title,.hljs-section,.hljs-selector-id{color:#900;font-weight:bold}.hljs-subst{font-weight:normal}.hljs-type,.hljs-class .hljs-title{color:#458;font-weight:bold}.hljs-tag,.hljs-name,.hljs-attribute{color:#000080;font-weight:normal}.hljs-regexp,.hljs-link{color:#009926}.hljs-symbol,.hljs-bullet{color:#990073}.hljs-built_in,.hljs-builtin-name{color:#0086b3}.hljs-meta{color:#999;font-weight:bold}.hljs-deletion{background:#fdd}.hljs-addition{background:#dfd}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
     </style>

--- a/content/download/0.3.0/release-notes.html
+++ b/content/download/0.3.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.3.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       #contents {
         max-width: 50em;

--- a/content/download/0.4.0/release-notes.html
+++ b/content/download/0.4.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.4.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.5.0/release-notes.html
+++ b/content/download/0.5.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.5.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.6.0/release-notes.html
+++ b/content/download/0.6.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.6.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.7.0/release-notes.html
+++ b/content/download/0.7.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.7.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.7.1/release-notes.html
+++ b/content/download/0.7.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.7.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.8.0/release-notes.html
+++ b/content/download/0.8.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.8.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.8.1/release-notes.html
+++ b/content/download/0.8.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.8.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/content/download/0.9.0/release-notes.html
+++ b/content/download/0.9.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.9.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/content/download/0.9.1/release-notes.html
+++ b/content/download/0.9.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.9.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/src/download/0.10.0/release-notes.html
+++ b/src/download/0.10.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.10.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/src/download/0.10.1/release-notes.html
+++ b/src/download/0.10.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.10.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/src/download/0.11.0/release-notes.html
+++ b/src/download/0.11.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.11.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/src/download/0.4.0/release-notes.html
+++ b/src/download/0.4.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.4.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style type="text/css">
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.5.0/release-notes.html
+++ b/src/download/0.5.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.5.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="../../favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.6.0/release-notes.html
+++ b/src/download/0.6.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.6.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.7.0/release-notes.html
+++ b/src/download/0.7.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.7.0 Release Notes &middot; The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.7.1/release-notes.html
+++ b/src/download/0.7.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.7.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.8.0/release-notes.html
+++ b/src/download/0.8.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.8.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.8.1/release-notes.html
+++ b/src/download/0.8.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.8.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       body{
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;

--- a/src/download/0.9.0/release-notes.html
+++ b/src/download/0.9.0/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.9.0 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/src/download/0.9.1/release-notes.html
+++ b/src/download/0.9.1/release-notes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>0.9.1 Release Notes ⚡ The Zig Programming Language</title>
-    <link rel="icon" href="https://ziglang.org/favicon.png">
+    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="/favicon.svg">
     <style>
       :root{
          --nav-width: 24em;

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140">
+<g fill="#F7A41D">
+	<g>
+		<polygon points="46,22 28,44 19,30"/>
+		<polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
+		<polygon points="31,95 12,117 4,106"/>
+	</g>
+	<g>
+		<polygon points="56,22 62,36 37,44"/>
+		<polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
+		<polygon points="116,95 97,117 90,104"/>
+		<polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
+		<polygon points="150,0 52,117 3,140 101,22"/>
+	</g>
+	<g>
+		<polygon points="141,22 140,40 122,45"/>
+		<polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
+		<polygon points="125,95 130,110 106,117"/>
+	</g>
+</g>
+</svg>

--- a/themes/ziglang-original/layouts/_default/baseof.html
+++ b/themes/ziglang-original/layouts/_default/baseof.html
@@ -14,7 +14,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="color-scheme" content="light dark">
 
-    <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAgklEQVR4AWMYWuD7EllJIM4G4g4g5oIJ/odhOJ8wToOxSTXgNxDHoeiBMfA4+wGShjyYOCkG/IGqWQziEzYAoUAeiF9D5U+DxEg14DRU7jWIT5IBIOdCxf+A+CQZAAoopEB7QJwBCBwHiip8UYmRdrAlDpIMgApwQZNnNii5Dq0MBgCxxycBnwEd+wAAAABJRU5ErkJggg==">
+		<link rel="icon" href="/favicon.png">
+		<link rel="icon" href="/favicon.svg">
+
 		{{ $style := resources.Get "css/style.css" }}
 		<link type="text/css" rel="stylesheet" href="{{ $style.Permalink }}">
 


### PR DESCRIPTION
![zig-favicon](https://github.com/ziglang/www.ziglang.org/assets/475017/0ba47d20-4161-4da2-981e-03b69d7c21ec)

The SVG looks way better than the pixelated PNG and will adapt best to whatever screen it is being displayed on. The PNG continues to be used because Apple Safari does not support SVG favicons yet. All other major
browsers do. See https://caniuse.com/link-icon-svg.

All non-embedded instances of the link icon tag were changed to be relative to the root of the host.

If this PR is accepted, I will do a follow-up on the main repository that adds an embedded copy to the reference documentation templates.