### PR TITLE
downloads: dark borders for light mode

### DIFF
--- a/themes/ziglang-original/assets/css/style.css
+++ b/themes/ziglang-original/assets/css/style.css
@@ -92,7 +92,7 @@ td {
 }
 
 th, .last-row-in-section {
-  border-bottom: 2px solid #f2f3f3;
+  border-bottom: 2px solid #aaa;
 }
 
 tr:nth-child(even)>td {


### PR DESCRIPTION
The borders that separate each OS section in the download table are hard to see in light mode.  The color is currently shared with the background color used for every other row (#f2f3f3).  Note that in dark mode we use the color grey for these borders which is #888.  This has a much higher contrast with the background than light mode.  I've changed it to #aaa which is much more visible.

This change was a result of a user getting confused because they couldn't see that the x86_64 linux variant was apart of the "Linux" section.

# CURRENT
![image](https://github.com/ziglang/www.ziglang.org/assets/304904/f25b6717-07f4-41e4-b8c8-eb7b30cf9132)

# With this PR

![image](https://github.com/ziglang/www.ziglang.org/assets/304904/7b7ec3dd-1cae-494d-871d-f858cbe19c21)



