### PR TITLE
typo in fragment of URL

### DIFF
--- a/src/download/0.11.0/release-notes.html
+++ b/src/download/0.11.0/release-notes.html
@@ -1822,7 +1822,7 @@ test "qualCast" {
     </p>
     <p>
     This language change removes the destination type parameter from all cast builtins. Instead,
-    these builtins now use <a href="/documentation/0.11.0/#Reuslt-Location-Semantics">Result Location Semantics</a>
+    these builtins now use <a href="/documentation/0.11.0/#Result-Location-Semantics">Result Location Semantics</a>
     to infer the result type of the cast from the expression's "result type". In essence, this means
     type inference is used. Most expressions which have a known concrete type for their operand will
     provide a result type. For instance:


### PR DESCRIPTION
This causes you to end up at the top of the Language Reference, instead of at the section Result Location Semantics