### PR TITLE
fix(ui): footer language names text wrapping

### DIFF
--- a/themes/ziglang-original/layouts/partials/footer.html
+++ b/themes/ziglang-original/layouts/partials/footer.html
@@ -4,7 +4,7 @@
   <div id="languages-menu">
     {{ i18n "footer-translation" }} <br>
     {{ range .Translations }}
-    <a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+    <a href="{{ .Permalink }}" style="white-space: nowrap;">{{ .Language.LanguageName }}</a>
     {{ end }}
   </div>
   {{ end }}


### PR DESCRIPTION
Notice how 日本語 is not split in the middle of the word anymore.

**Before:**

![image](https://github.com/ziglang/www.ziglang.org/assets/5113257/50200a3b-48ba-4957-b434-7674823d1bc8)

**After:**

![image](https://github.com/ziglang/www.ziglang.org/assets/5113257/428016cc-b014-41cc-93e9-d1101a3a243d)
