### PR TITLE
[German] Fixed typos and incorrect translations. Added missing translations

### DIFF
--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -112,6 +112,6 @@ Dank der Sponsoren von Zig ist das Projekt der Open-Source-Gemeinschaft gegenüb
 
 {{< ghsponsors >}}
 
-Dieser Abschnitt wird zu Beginn jedes Monats aktualisiert.
+Dieser Abschnitt wird zu Beginn jeden Monats aktualisiert.
 {{% /div %}}
 {{< /div >}}

--- a/content/learn/_index.de.md
+++ b/content/learn/_index.de.md
@@ -13,11 +13,11 @@ Dieser Abschnitt enthält Ressourcen, die hoffentlich helfen, Zigs Philosophie z
 {{% learn_docs %}}
 
 ## Guides
-This section is eventually going to be bundled with Zig's standard library documentation, but
-in the meantime you can browse it from here.
+Dieser Abschnitt wird irgendwann mit der Standardbibliotheksdokumentation von Zig gebündelt, aber
+in der Zwischenzeit können Sie ihn hier durchsuchen.
 
 - [Zig Build System](build-system/)
-Introduction to the Zig build system.
+Einführung in das Zig-Build-System.
 
 ## Einführung
 Einige Seiten zum Einstieg in Zig für Programmierer mit verschiedenen Vorkenntnissen:

--- a/content/news/_index.de.md
+++ b/content/news/_index.de.md
@@ -1,6 +1,6 @@
 ---
-title: News
-menu_title: "News (ENG)"
-mobile_menu_title: "News (ENG)"
+title: Neuigkeiten
+menu_title: "Neuigkeiten (ENG)"
+mobile_menu_title: "Neuigkeiten (ENG)"
 layout: news-list
 ---

--- a/content/zsf/index.de.md
+++ b/content/zsf/index.de.md
@@ -1,7 +1,7 @@
 ---
-title: "ZSF unterstützen"
-menu_title: "Die Zig Software Foundation unterstützen"
-mobile_menu_title: "Die ZSF unterstützen"
+title: "ZSF"
+menu_title: "Zig Software Foundation"
+mobile_menu_title: "Zig Software Foundation"
 date: 2020-10-20T16:29:51+02:00
 ---
 

--- a/themes/ziglang-original/i18n/de.toml
+++ b/themes/ziglang-original/i18n/de.toml
@@ -17,7 +17,7 @@ other = "Quellcode"
 
 
 [downloads-heading]
-other = "Releases"
+other = "Veröffentlichungen"
 
 [downloads-install-from-pkg-manager]
 other = "Du kannst Zig auch <a href=\"https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager\"> mit einem Paketmanager installieren</a>."

--- a/themes/ziglang-original/i18n/de.toml
+++ b/themes/ziglang-original/i18n/de.toml
@@ -1,5 +1,5 @@
 [slogan-latest-release]
-other = "Letztes Release: &nbsp; <b>{{ . }}</b>"
+other = "Letzte Veröffentlichung: &nbsp; <b>{{ . }}</b>"
 
 
 [back-to-home]

--- a/themes/ziglang-original/layouts/index.html
+++ b/themes/ziglang-original/layouts/index.html
@@ -13,10 +13,10 @@
 <div class="container parent-link" style="display:flex; flex-direction: row; justify-content: space-around; margin-top: 20px;">
 		{{ if ne .Lang "en"}}
 			{{ range where .Translations "Language.Lang" "en"}}
-			<span>This page was translated by the Zig community, 
- 				<a href="{{ .Permalink }}" class="no-mobile">see the original version</a> 
-				or 
-				<a href="https://github.com/ziglang/www.ziglang.org/" class="external-link no-mobile" target="_blank" rel="noopener">report errors</a>.
+			<span>Diese Seite wurde von der Zig-Community übersetzt. 
+ 				<a href="{{ .Permalink }}" class="no-mobile">Sehen Sie sich die Originalversion an</a> 
+				oder
+				<a href="https://github.com/ziglang/www.ziglang.org/" class="external-link no-mobile" target="_blank" rel="noopener">melden Sie Fehler</a>.
 			</span>
 			{{ end }}
 		{{ end }}


### PR DESCRIPTION
I added missing translations. Incorrect translations have also been revised, as an example there were 1 typo and a missing translation in "Letztes Release: ...", correct would be "Letzte Release: ..." (Because it's pronounced "Der letzte Release") but completely correct would be "Letzte Veröffentlichung: ..." (Because it's pronounced "Die letzte Veröffentlichung". Release > Veröffentlichung). Many people speak or write "Release" in German, but others "Veröffentlichung" and I think that's right because in my opinion mixing German and English words is wrong and less professional.

> [!NOTE]
> The word “Download” has already become established in German, although the correct word would be "Herunterladen", which is why I leave it unchanged.

The length of the navigation bar has also reduced:
![Unbenannt](https://github.com/ziglang/www.ziglang.org/assets/154023155/0d501d3e-5380-46d8-b33d-657f3d9933de)
