### PR TITLE
release notes: Clarify change in command line splitting on Windows

### DIFF
--- a/src/download/0.12.0/release-notes.html
+++ b/src/download/0.12.0/release-notes.html
@@ -1320,31 +1320,22 @@ test "@abs on int" {
 
     {#header_open|Standard Library#}
     {#header_open|Windows Command Line Argument Parsing#}
-    <p>On Windows, the command line arguments of a program are a single WTF-16
+    <p>On Windows, the command line arguments of a program are a single
+    <a href="https://simonsapin.github.io/wtf-8/#potentially-ill-formed-utf-16">WTF-16</a>
     encoded string and it's up to the program to split it into an array of
     strings. In C/C++, the entry point of the C runtime takes care of splitting
     the command line and passing argc/argv to the main function.</p>
 
-    <p>Previously, ArgIteratorWindows matched the behavior of
-    CommandLineToArgvW, but it turns out that CommandLineToArgvW's behavior
-    does not match the behavior of the C runtime post-2008. In 2008, the C
-    runtime argv splitting
-    <a href="https://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESDOC">changed how it handles consecutive double quotes</a>
-    within a quoted argument (it's now considered an escaped quote, e.g.
-    <code>"foo""bar"</code> post-2008 would get parsed into <code>foo"bar</code>), and the rules around
-    argv[0] were also changed.</p>
-    <p>This release makes ArgIteratorWindows match the behavior of the
-    post-2008 C runtime. The motivation here is roughly the same as when the
-    <a href="https://github.com/rust-lang/rust/pull/87580">same change was made in Rust</a>,
-    that is (paraphrased):</p>
-    <ul>
-      <li>Consistent behavior between Zig and modern C/C++ programs</li>
-      <li>Allows users to escape double quotes in a way that can be more straightforward</li>
-    </ul>
-    <p>Additionally, the suggested mitigation for
+    <p>Previously, <code>std.process.argsAlloc</code> and related functions did not fully match the parsing behavior of
+    the C runtime and would split the command line incorrectly in some cases. For example, when encountering consecutive
+    double quotes inside a quoted block like <code>"foo""bar"</code>, these functions would produce <code>foobar</code>
+    instead of the expected <code>foo"bar</code></p>
+    <p>This release updates Zig's command line splitting to match
+    <a href="https://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESDOC">the post-2008 splitting behavior of the C runtime</a>,
+    which ensures consistent behavior between Zig and modern C/C++ programs on Windows.
+    Additionally, the suggested mitigation for
     <a href="https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/">BatBadBut</a>
-    relies on the post-2008 argv splitting behavior for roundtripping of the
-    arguments given to cmd.exe.</p>
+    relies on the post-2008 C runtime splitting behavior for roundtripping of the arguments given to cmd.exe.</p>
     <p>The <a href="https://github.com/ziglang/zig/pull/19698">BadBatBut
     mitigation</a> did not make the 0.12.0 release cutoff.</p>
     {#header_close#}
@@ -2157,7 +2148,7 @@ error: the following build command crashed:
 
     <p>Migration guide:</p>
 
-    <p>installHeader now takes a <code>LazyPath</code>:</p>
+    <p><code>Compile.installHeader</code> now takes a <code>LazyPath</code>:</p>
     {#syntax_block|zig#}
     for (headers) |h| lib.installHeader(h, h);
     {#end_syntax_block#}
@@ -2202,26 +2193,27 @@ error: the following build command crashed:
         },
     });
     {#end_syntax_block#}
+    <p>Additionally:</p>
     <ul>
-      <li>[Breaking] <code>b.addInstallHeaderFile</code> now takes a <code>LazyPath</code>.</li>
-      <li>[Breaking] As a workaround for
+      <li><code>b.addInstallHeaderFile</code> now takes a <code>LazyPath</code>.</li>
+      <li>As a workaround for
       <a href="https://github.com/ziglang/zig/issues/9698">resurrect emit-h</a>, the generated
-      <code>-femit-h</code> header is now never emitted even when the user specifies an
-      override for h_dir. If you absolutely need the emitted header, you now
+      <code>-femit-h</code> header is no longer emitted even when the user specifies an
+      override for <code>h_dir</code>. If you absolutely need the emitted header, you now
       need to do {#syntax#}install_artifact.emitted_h = artifact.getEmittedH(){#endsyntax#} until
       <code>-femit-h</code> is fixed.</li>
       <li>Added <code>WriteFile.addCopyDirectory</code>, which functions very similar to InstallDir.</li>
-      <li><code>InstallArtifact</code> has been updated to install the bundled headers alongide the artifact. The bundled headers are installed to the directory specified by h_dir (which is <code>zig-out/include</code> by default).</li>
+      <li><code>InstallArtifact</code> has been updated to install the bundled headers alongide the artifact. The bundled headers are installed to the directory specified by <code>h_dir</code> (which is <code>zig-out/include</code> by default).</li>
     </ul>
     {#header_close#}
 
     {#header_open|dependencyFromBuildZig#}
-    <p>Given a struct that corresponds to the build.zig of a dependency, <code>b.dependencyFromBuildZig</code> returns that same dependency. In other words, if you have already a <code>@import</code>ed a depdency&#39;s build.zig, you can use this function to obtain the corresponding <code>Dependency</code>:</p>
+    <p>Given a struct that corresponds to the build.zig of a dependency, <code>b.dependencyFromBuildZig</code> returns that same dependency. In other words, if you have already <code>@import</code>ed a dependency&#39;s build.zig struct, you can use this function to obtain a corresponding <code>Dependency</code>:</p>
     {#syntax_block|zig#}
 // in consumer build.zig
 const foo_dep = b.dependencyFromBuildZig(@import("foo"), .{});
     {#end_syntax_block#}
-    <p>This function is also important for packages that expose functions from their build.zig files that need to use their corresponding <code>Dependency</code> (for example, for package-relative paths, or for running system commands and returning the output as lazy paths). This would be accomplished through:</p>
+    <p>This function is useful for packages that expose functions from their build.zig files that need to use their corresponding <code>Dependency</code>, such as for accessing package-relative paths, or for running system commands and returning the output as lazy paths. This can now be accomplished through:</p>
     
     {#syntax_block|zig#}
 // in dependency build.zig


### PR DESCRIPTION
0.11.0 did not implement CommandLineToArgvW (this was done in the middle of the 0.12.0 release cycle), so it's probably more useful to emphasize that 0.12.0 fixes parsing bugs present in 0.11.0.

Also fixes some typos in and rephrases some build system notes.