### PR TITLE
Update build system examples for latest master Zig

### DIFF
--- a/assets/zig-code/build-system/1-simple-executable/build.zig
+++ b/assets/zig-code/build-system/1-simple-executable/build.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "hello.zig" },
+        .root_source_file = b.path("hello.zig"),
         .target = b.host,
     });
 

--- a/assets/zig-code/build-system/10-release/build.zig
+++ b/assets/zig-code/build-system/10-release/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) !void {
     for (targets) |t| {
         const exe = b.addExecutable(.{
             .name = "hello",
-            .root_source_file = .{ .path = "hello.zig" },
+            .root_source_file = b.path("hello.zig"),
             .target = b.resolveTargetQuery(t),
             .optimize = .ReleaseSafe,
         });

--- a/assets/zig-code/build-system/10.5-system-tool/build.zig
+++ b/assets/zig-code/build-system/10.5-system-tool/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
         , .{lang}),
         "-r", // raw output to omit quotes around the selected string
     });
-    tool_run.addFileArg(.{ .path = "words.json" });
+    tool_run.addFileArg(b.path("words.json"));
 
     const output = tool_run.captureStdOut();
 
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/assets/zig-code/build-system/11-zig-tool/build.zig
+++ b/assets/zig-code/build-system/11-zig-tool/build.zig
@@ -5,13 +5,13 @@ pub fn build(b: *std.Build) void {
     const lang = b.option([]const u8, "language", "language of the greeting") orelse "en";
     const tool = b.addExecutable(.{
         .name = "word_select",
-        .root_source_file = .{ .path = "tools/word_select.zig" },
+        .root_source_file = b.path("tools/word_select.zig"),
         .target = b.host,
     });
 
     const tool_step = b.addRunArtifact(tool);
     tool_step.addArg("--input-file");
-    tool_step.addFileArg(.{ .path = "tools/words.json" });
+    tool_step.addFileArg(b.path("tools/words.json"));
     tool_step.addArg("--output-file");
     const output = tool_step.addOutputFileArg("word.txt");
     tool_step.addArgs(&.{ "--lang", lang });
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/assets/zig-code/build-system/12-embedfile/build.zig
+++ b/assets/zig-code/build-system/12-embedfile/build.zig
@@ -5,13 +5,13 @@ pub fn build(b: *std.Build) void {
     const lang = b.option([]const u8, "language", "language of the greeting") orelse "en";
     const tool = b.addExecutable(.{
         .name = "word_select",
-        .root_source_file = .{ .path = "tools/word_select.zig" },
+        .root_source_file = b.path("tools/word_select.zig"),
         .target = b.host,
     });
 
     const tool_step = b.addRunArtifact(tool);
     tool_step.addArg("--input-file");
-    tool_step.addFileArg(.{ .path = "tools/words.json" });
+    tool_step.addFileArg(b.path("tools/words.json"));
     tool_step.addArg("--output-file");
     const output = tool_step.addOutputFileArg("word.txt");
     tool_step.addArgs(&.{ "--lang", lang });
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/assets/zig-code/build-system/13-import/build.zig
+++ b/assets/zig-code/build-system/13-import/build.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const tool = b.addExecutable(.{
         .name = "generate_struct",
-        .root_source_file = .{ .path = "tools/generate_struct.zig" },
+        .root_source_file = b.path("tools/generate_struct.zig" },
         .target = b.host,
     });
 
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/assets/zig-code/build-system/2-user-provided-options/build.zig
+++ b/assets/zig-code/build-system/2-user-provided-options/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "example.zig" },
+        .root_source_file = b.path("example.zig"),
         .target = b.resolveTargetQuery(.{
             .os_tag = if (windows) .windows else null,
         }),

--- a/assets/zig-code/build-system/3-standard-config-options/build.zig
+++ b/assets/zig-code/build-system/3-standard-config-options/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "hello.zig" },
+        .root_source_file = b.path("hello.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/assets/zig-code/build-system/conditional-compilation/build.zig
+++ b/assets/zig-code/build-system/conditional-compilation/build.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "app",
-        .root_source_file = .{ .path = "app.zig" },
+        .root_source_file = b.path("app.zig"),
         .target = b.host,
     });
 

--- a/assets/zig-code/build-system/convenience-run-step/build.zig
+++ b/assets/zig-code/build-system/convenience-run-step/build.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = .{ .path = "hello.zig" },
+        .root_source_file = b.path("hello.zig"),
         .target = b.host,
     });
 

--- a/assets/zig-code/build-system/dynamic-library/build.zig
+++ b/assets/zig-code/build-system/dynamic-library/build.zig
@@ -7,7 +7,7 @@ pub fn build(b: *std.Build) void {
 
     const libfizzbuzz = b.addSharedLibrary(.{
         .name = "fizzbuzz",
-        .root_source_file = .{ .path = "fizzbuzz.zig" },
+        .root_source_file = b.path("fizzbuzz.zig"),
         .target = target,
         .optimize = optimize,
         .version = .{ .major = 1, .minor = 2, .patch = 3 },

--- a/assets/zig-code/build-system/mutate-source-files/build.zig
+++ b/assets/zig-code/build-system/mutate-source-files/build.zig
@@ -4,13 +4,13 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "demo",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
     });
     b.installArtifact(exe);
 
     const proto_gen = b.addExecutable(.{
         .name = "proto_gen",
-        .root_source_file = .{ .path = "tools/proto_gen.zig" },
+        .root_source_file = b.path("tools/proto_gen.zig"),
     });
 
     const run = b.addRunArtifact(proto_gen);

--- a/assets/zig-code/build-system/simple-static-library/build.zig
+++ b/assets/zig-code/build-system/simple-static-library/build.zig
@@ -7,14 +7,14 @@ pub fn build(b: *std.Build) void {
 
     const libfizzbuzz = b.addStaticLibrary(.{
         .name = "fizzbuzz",
-        .root_source_file = .{ .path = "fizzbuzz.zig" },
+        .root_source_file = b.path("fizzbuzz.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const exe = b.addExecutable(.{
         .name = "demo",
-        .root_source_file = .{ .path = "demo.zig" },
+        .root_source_file = b.path("demo.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/assets/zig-code/build-system/system-libraries/build.zig
+++ b/assets/zig-code/build-system/system-libraries/build.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "zip",
-        .root_source_file = .{ .path = "zip.zig" },
+        .root_source_file = b.path("zip.zig"),
         .target = b.host,
     });
 

--- a/assets/zig-code/build-system/unit-testing-skip-foreign/build.zig
+++ b/assets/zig-code/build-system/unit-testing-skip-foreign/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
 
     for (test_targets) |target| {
         const unit_tests = b.addTest(.{
-            .root_source_file = .{ .path = "main.zig" },
+            .root_source_file = b.path("main.zig"),
             .target = b.resolveTargetQuery(target),
         });
 

--- a/assets/zig-code/build-system/unit-testing/build.zig
+++ b/assets/zig-code/build-system/unit-testing/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
 
     for (test_targets) |target| {
         const unit_tests = b.addTest(.{
-            .root_source_file = .{ .path = "main.zig" },
+            .root_source_file = b.path("main.zig"),
             .target = b.resolveTargetQuery(target),
         });
 

--- a/assets/zig-code/build-system/write-files/build.zig
+++ b/assets/zig-code/build-system/write-files/build.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "app",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = b.host,
     });
 


### PR DESCRIPTION
Must use `b.path` instead, constructing a LazyPath with `path` is deprecated since dee9f82f69db0d034251b844e0bc4083a1b25fdd.

All the examples now build for me locally and so the website builds. I'm hoping this is the last PR needed to get the CI that deploys the tarballs working again.