### PR TITLE
Add UTMs to the Transloadit sponsorship link

### DIFF
--- a/assets/github-sponsors.html
+++ b/assets/github-sponsors.html
@@ -4,7 +4,7 @@
 <li><a href="https://mitchellh.com" rel="nofollow noopener" target="_blank" class="external-link">Mitchell Hashimoto</a></li>
 <li><a href="https://bun.sh/" rel="nofollow noopener" target="_blank" class="external-link">Bun</a></li>
 <li><a href="https://huly.io" rel="nofollow noopener" target="_blank" class="external-link">Huly® Platform™</a></li>
-<li><a href="https://transloadit.com/" rel="nofollow noopener" target="_blank" class="external-link">Transloadit</a></li>
+<li><a href="https://transloadit.com/?utm_source=ziglang&utm_medium=referral&utm_campaign=sponsorship&utm_content=website" rel="nofollow noopener" target="_blank" class="external-link">Transloadit</a></li>
 <li>Stevie Hryciw</li>
 <li>Karrick McDermott</li>
 <li>Joran Dirk Greef</li>


### PR DESCRIPTION
Hi there,

Iʼm Alex, a designer from [Transloadit](https://transloadit.com/). Weʼve recently started sponsoring Zig, and weʼre thankful for being added to your Sponsor list. However, weʼd like to include some UTM parameters to our sponsorship link to better track and analyze our marketing efforts. This PR adds those parameters.

P.S. We requested these changes via email but did not receive a response, so we decided to open a PR.

Thank you for considering this request!