### PR TITLE
Fix off-by-1 in update-gh-sponsors.zig

### DIFF
--- a/.github/workflows/update-gh-sponsors.zig
+++ b/.github/workflows/update-gh-sponsors.zig
@@ -197,7 +197,7 @@ pub fn main() !void {
                 100...199 => {
                     try notes_with_link.append(s.sponsorEntity);
                 },
-                200...400 => {
+                200...399 => {
                     try home_name_only.append(s.sponsorEntity);
                     try notes_with_link.append(s.sponsorEntity);
                 },


### PR DESCRIPTION
Seems to have been erroneously introduced by ee65dbe1c10df49e24942e47e5fb182e32e63654