### PR TITLE
Arabic Translation for the 'Guides' Section in 'learn' page

### DIFF
--- a/content/learn/_index.ar.md
+++ b/content/learn/_index.ar.md
@@ -13,11 +13,11 @@ layout: single
 {{% learn_docs %}}
 
 ## Guides
-This section is eventually going to be bundled with Zig's standard library documentation, but
-in the meantime you can browse it from here.
+سيُجمع هذا القسم في النهاية مع وثائق المكتبة الفياسية لـZig, لكن
+في هذه الأثناء يمكنك تصفحها هنا.
 
-- [Zig Build System](build-system/)
-Introduction to the Zig build system.
+- [نظام البناء في Zig](build-system/)
+مقدمة لنظام البناء في Zig.
 
 
 ## مقدمة


### PR DESCRIPTION
### Description
This PR translates the 'Guides' section in the 'learn' page to Arabic, ( [link to the referenced page](https://ziglang.org/ar/learn/) ).