### PR TITLE
Set service logos flex container to column

### DIFF
--- a/themes/ziglang-original/layouts/shortcodes/services-sponsor-logos.html
+++ b/themes/ziglang-original/layouts/shortcodes/services-sponsor-logos.html
@@ -10,6 +10,7 @@
 
   .services-logos p {
     display:  flex;
+    flex-direction: column;
     align-items: center;
   }
 


### PR DESCRIPTION
This prevents poor mobile layout, since this container was making the document width be larger than the screen.

Before:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/a52232e0-5458-4173-9d0e-2883c2a31bf4">


After:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/724512ea-84bc-473b-b48b-4e2904142305">
