### PR TITLE
monetary-sponsor-logos: remove url tracking params from blacksmith

### DIFF
--- a/themes/ziglang-original/layouts/shortcodes/monetary-sponsor-logos.html
+++ b/themes/ziglang-original/layouts/shortcodes/monetary-sponsor-logos.html
@@ -73,7 +73,7 @@
      <img src="/shiguredo-logo-light.svg">
    </picture>
  </a>
- <a href="https://blacksmith.sh/?utm_source=ziglang&utm_medium=banner&utm_campaign=zig" rel="noopener nofollow" target="_blank">
+ <a href="https://blacksmith.sh/" rel="noopener nofollow" target="_blank">
    <picture>
      <source srcset="/Blacksmith_Logo-White.svg" media="(prefers-color-scheme: dark)">
      <img src="/Blacksmith_Logo-Black.svg">


### PR DESCRIPTION
this doesn't appear to be on any of the other ones