### PR TITLE
build-tarballs.sh: Replace generic+v7a with baseline.

### DIFF
--- a/.github/workflows/build-tarballs.sh
+++ b/.github/workflows/build-tarballs.sh
@@ -111,7 +111,7 @@ CMAKE_GENERATOR=Ninja ./build x86-linux-musl baseline
 CMAKE_GENERATOR=Ninja ./build x86_64-windows-gnu baseline
 CMAKE_GENERATOR=Ninja ./build aarch64-windows-gnu baseline
 CMAKE_GENERATOR=Ninja ./build x86-windows-gnu baseline
-CMAKE_GENERATOR=Ninja ./build arm-linux-musleabihf generic+v7a
+CMAKE_GENERATOR=Ninja ./build arm-linux-musleabihf baseline
 
 ZIG="$BOOTSTRAP_SRC/out/host/bin/zig"
 


### PR DESCRIPTION
v7a is already Zig's baseline: https://github.com/ziglang/zig/blob/218cf059dd215282aa96d6b4715e68d533a4238e/tools/update_cpu_features.zig#L369-L373