### PR TITLE
i18n: revamp Italian translation

### DIFF
--- a/content/en-US/zsf.smd
+++ b/content/en-US/zsf.smd
@@ -70,8 +70,8 @@ Make sure to check your local law to see if you can deduct donations from your t
 84-5105214
 
 ## Address
-Zig Software Foundation
-1632 1st Ave #21385
+Zig Software Foundation  
+1632 1st Ave #21385  
 New York, NY 10028
 
 ## Additional donation methods supported

--- a/content/en-US/zsf.smd
+++ b/content/en-US/zsf.smd
@@ -9,8 +9,7 @@
 ---
 # Sponsoring the Zig Software Foundation
 
-Please consider a recurring donation. It takes ongoing labor to maintain
-and support high-quality software!
+Please consider a recurring donation. It takes ongoing labor to maintain and support high-quality software!
 
 ```=html
 <div id="zsf-every-donate-btn">
@@ -71,8 +70,8 @@ Make sure to check your local law to see if you can deduct donations from your t
 84-5105214
 
 ## Address
-Zig Software Foundation  
-1632 1st Ave #21385  
+Zig Software Foundation
+1632 1st Ave #21385
 New York, NY 10028
 
 ## Additional donation methods supported

--- a/content/it-IT/download.smd
+++ b/content/it-IT/download.smd
@@ -8,11 +8,11 @@
 },
 ---
 # Rilasci
-Puoi anche [ottenere Zig da un package manager](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager).
+Puoi anche [installare Zig con un gestore di pacchetti](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager).
 
-Questa pagina e' [disponibile anche in formato JSON]($link.siteAsset('download/index.json')).
+Questa pagina è [disponibile anche in formato JSON]($link.siteAsset('download/index.json')).
 
-Tutti gli archivi sono firmati con minisign usando la seguente chiave pubblica:
+Tutti gli archivi sono firmati con [minisign](https://jedisct1.github.io/minisign/) usando la seguente chiave pubblica:
 
 ```
 RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U

--- a/content/it-IT/index.smd
+++ b/content/it-IT/index.smd
@@ -1,5 +1,5 @@
 ---
-.title = "Pagina Principale",
+.title = "Pagina principale",
 .author = "",
 .date = @date("2024-08-07:00:00:00"),
 .layout = "index.shtml",
@@ -9,50 +9,55 @@
 ---
 
 []($section.id("slogan"))
-Zig è un linguaggio di programmazione general-purpose e toolchain per
-mantenere software **robusto**, **ottimale**, e **riusabile**.
+Zig è un linguaggio di programmazione ad uso generale e un insieme di strumenti per mantenere software **robusto**, **ottimale**, e **riusabile**.
 
 []($section.id("features"))
-## ⚡ Un Linguaggio Semplice
+## ⚡ Un linguaggio semplice
 Concentrati nel debuggare la tua applicazione, invece di debuggare la tua conoscenza del linguaggio di programmazione.
 
 - Nessun controllo di flusso implicito.
 - Niente allocazioni dinamiche implicite.
-- Nessun preprocessore, niente macro. 
+- Nessun preprocessore, niente macro.
 
 ## ⚡ Comptime
 Un nuovo approccio alla metaprogrammazione basato sull'esecuzione di codice durante la compilazione e valutazione pigra del codice.
 
-- Chiama qualunque funzione mentre compili.
-- Manipola tipi come valori senza nessuno spreco a runtime.
-- Comptime emula l'archittetura per cui stai compilando.
+- Esegui qualunque funzione in fase di compilazione.
+- Manipola i tipi come valori, senza alcuna penalità a runtime.
+- Comptime emula l'architettura per cui stai compilando.
 
 ## ⚡ Mantienilo con Zig
 Migliora gradualmente il tuo codice C/C++/Zig.
 
-- Il compilatore Zig puo' sostituire altri compilatori C/C++, non richiede dipendenze e supporta cross-compilazione nativamente.
-- Usa `zig build` per creare un ambiente di sviluppo consistente su più piattaforme.
-- Aggiungi una unita' di compilazione Zig ai tuoi progetti C/C++; LTO tra i vari linguaggi è abilitato di default.
+- Il compilatore Zig può sostituire altri compilatori C/C++, non richiede dipendenze e supporta nativamente la cross-compilazione.
+- Usa `zig build` per creare un ambiente di sviluppo consistente su ogni piattaforma.
+- Aggiungi un'unità di compilazione Zig ai tuoi progetti C/C++, esponendo la ricca libreria standard di Zig al tuo codice C/C++.
+
 
 # [Community]($section.id("community").attrs("section-title"))
-# [La comunità e' decentralizzata]($section.id("decentralized")) 
-Chiunque è libero di avviare e mantenere un proprio spazio per permettere alla comunità di interagire.
-Non c'è nessuna distinzione tra spazi "ufficiali" e non, ma ogni posto ha le proprie regole e moderatori.
 
-# [Sviluppo del progetto]($section.id("main-development"))
-Il repository di Zig può essere trovato a [https://github.com/ziglang/zig](https://github.com/ziglang/zig), dove manteniamo anche l'issue tracker e discutiamo le proposte di miglioramento.  
+## [La comunità Zig è decentralizzata]($section.id("decentralized"))
+Chiunque è libero di avviare e moderare un proprio spazio per permettere alla comunità di interagire.
+Non c'è distinzione tra spazi "ufficiali" e non, ma ogni spazio ha le proprie regole e moderatori.
+
+
+## [Sviluppo del progetto]($section.id("main-development"))
+Il repository di Zig può essere trovato a [https://github.com/ziglang/zig](https://github.com/ziglang/zig), dove gestiamo anche le segnalazioni di bug e discutiamo le proposte di miglioramento.
 I contributori sono tenuti a rispettare il [codice di comportamento](https://github.com/ziglang/zig/blob/master/.github/CODE_OF_CONDUCT.md) di Zig.
+
 
 # [Zig Software Foundation]($section.id("zsf").attrs("section-title"))
 
-## La ZSF è una corporazione non-profit.
-La Zig Software Foundation è una corporazione non-profit fondata nel 2020 da Andrew Kelley, il creatore di Zig, con l'obbiettivo di supportare lo sviluppo del linguaggio. Al momento la fondazione è in grado di offire pagamenti con tariffe competitive ad un piccolo numero di contributori. Speriamo di poter estendere questa offerta a più contibutori nel prossimo futuro.
+## La ZSF è un'associazione non-profit.
+
+La Zig Software Foundation è un'associazione non-profit fondata nel 2020 da Andrew Kelley, il creatore di Zig, con l'obiettivo di supportare lo sviluppo del linguaggio. Al momento l'associazione è in grado di offire del lavoro pagato con tariffe competitive ad un piccolo numero di collaboratori. Speriamo di poter estendere questa offerta a più contributori nel prossimo futuro.
 
 La Zig Software Foundation si sostiene tramite donazioni.
 
-# [Sponsors]($section.id('sponsors').attrs('section-title'))
-# [Aziende sponsor]($section.id("corporate-sponsors")) 
-Le seguenti compagnie offrono diretto supporto finanziario alla Zig Software Foundation.
+# [Sponsor]($section.id('sponsors').attrs('section-title'))
 
-# [GitHub Sponsors]($section.id("github-sponsors"))
-Grazie a tutte le persone che [supportano Zig](/zsf/), il progetto fa riferimento all propria comunità open source, invece che ad uno stuolo di shareholder. In particolare, i seguenti illustri individui supportano Zig per un quantitativo di 200 USD/mese o superiore:
+## [Aziende sponsor]($section.id("corporate-sponsors"))
+Le seguenti aziende offrono supporto finanziario diretto alla Zig Software Foundation.
+
+## [GitHub Sponsors]($section.id("github-sponsors"))
+Grazie a tutte le persone che [supportano Zig]($link.page('zsf'), il progetto fa riferimento all propria comunità open source, invece che ad uno stuolo di shareholder. In particolare, i seguenti illustri individui supportano Zig per un quantitativo di 200 USD/mese o superiore:

--- a/content/it-IT/index.smd
+++ b/content/it-IT/index.smd
@@ -60,4 +60,4 @@ La Zig Software Foundation si sostiene tramite donazioni.
 Le seguenti aziende offrono supporto finanziario diretto alla Zig Software Foundation.
 
 ## [GitHub Sponsors]($section.id("github-sponsors"))
-Grazie a tutte le persone che [supportano Zig]($link.page('zsf'), il progetto fa riferimento all propria comunità open source, invece che ad uno stuolo di shareholder. In particolare, i seguenti illustri individui supportano Zig per un quantitativo di 200 USD/mese o superiore:
+Grazie a tutte le persone che [supportano Zig]($link.page('zsf')), il progetto fa riferimento all propria comunità open source, invece che ad uno stuolo di shareholder. In particolare, i seguenti illustri individui supportano Zig per un quantitativo di 200 USD/mese o superiore:

--- a/content/it-IT/learn/getting-started.smd
+++ b/content/it-IT/learn/getting-started.smd
@@ -1,38 +1,39 @@
 ---
-.title = "Getting Started",
+.title = "Inizia qui",
 .author = "",
 .date = @date("2024-08-07:00:00:00"),
 .layout = "page.shtml",
 .custom = {
-	"mobile_menu_title": "Getting Started",
+	"mobile_menu_title": "Inizia qui",
 	"toc": true,
 },
 ---
 
-# Tagged release or nightly build?
-Zig has not yet reached v1.0 and the current release cycle is tied to new releases of LLVM, which have a ~6 months cadence.
-In practical terms, **Zig releases tend to be far apart and eventually become stale given the current speed of development**.
+# Rilasci taggati o build nightly?
+Zig non ha ancora raggiunto la versione 1.0 e il ciclo di rilasci corrente è legato ai nuovi rilasci di LLVM, cha avvengono
+circa ogni 6 mesi. In sostanza, **i rilasci di Zig tendono ad essere distanti tra loro e a diventano obsoleti in poco tempo,
+per via dei rapidi progressi nello sviluppo**.
 
-It's fine to evaluate Zig using a tagged version, but if you decide that you like Zig and 
-want to dive deeper, **we encourage you to upgrade to a nightly build**, mainly because 
-that way it will be easier for you to get help: most of the community and sites like 
-[zig.guide](https://zig.guide) track the master branch for the reasons stated above.
+Puoi tranquillamente provare Zig con una versione taggata, ma se decidi che Zig ti piace
+e vuoi approfondire, **ti incoraggiamo a passare alle build nightly**, principalmente perchè
+in questo modo ti sarà più semplice ricevere supporto: la maggior parte della comunità
+e siti come [zig.guide](https://zig.guide) seguono gli sviluppi più recenti per le ragioni espresse qui sopra.
 
-The good news is that it's very easy to switch from one Zig version to another, or even have multiple versions present on the system at the same time: Zig releases are self-contained archives that can be placed anywhere in your system.
+La buona notizia è che è molto semplice passare da una versione di Zig all'altra, o persino avere più versioni di Zig installate allo stesso tempo: i rilasci di Zig sono archivi contenenti tutto il necessario e li puoi posizionare dovunque nel tuo sistema.
 
 
-# Installing Zig
-## [Direct download]($heading.id('direct'))
-This is the most straight-forward way of obtaining Zig: grab a Zig bundle for your platform from the [Downloads](/download) page,
-extract it in a directory and add it to your `PATH` to be able to call `zig` from any location.
+# Installare Zig
+## [Download diretto]($heading.id('direct'))
+Questo è il metodo più semplice di ottenere Zig: scarica un archivio per la tua piattaforma dalla pagina [Download](/download),
+estrailo in una cartella e aggiungila al tuo `PATH` per poter richiamare `zig` da qualunque posizione.
 
-### Setting up PATH on Windows
-To setup your path on Windows run **one** of the following snippets of code in a Powershell instance.
-Choose if you want to apply this change on a system-wide level (requires running Powershell with admin privileges)
-or just for your user, and **make sure to change the snippet to point at the location where your copy of Zig lies**.
-The `;` before `C:` is not a typo.
+### Impostare il PATH su Windows
+Per impostare la variabile d'ambiente PATH su Windows, esegui **uno** dei seguenti comandi in un terminale PowerShell.
+Scegli se vuoi applicare questo cambiamento per tutti gli utenti (richiede l'avvio di PowerShell con privilegi di amministratore)
+o solo per l'utente attuale, e **assicurati di modificare il comando in modo che il percorso corrisponda a quello della cartella che contiene Zig**.
+Il carattere `;` prima di `C:` non è un errore di battitura.
 
-System wide (**admin** Powershell):
+Per tutti gli utenti (Powershell con **privilegi di amministratore**):
 ```
 [Environment]::SetEnvironmentVariable(
    "Path",
@@ -41,7 +42,7 @@ System wide (**admin** Powershell):
 )
 ```
 
-User level (Powershell):
+Per l'utente attuale (Powershell):
 ```
 [Environment]::SetEnvironmentVariable(
    "Path",
@@ -49,40 +50,40 @@ User level (Powershell):
    "User"
 )
 ```
-After you're done, restart your Powershell instance.
+Quando hai finito, riavvia PowerShell.
 
-### Setting up PATH on Linux, macOS, BSD
-Add the location of your zig binary to your PATH environment variable.
+### Impostare il PATH su Linux, macOS, BSD
+Aggiungi il percorso del tuo eseguibile `zig` alla tua variabile d'ambiente PATH.
 
-This is generally done by adding an export line to your shell startup script (`.profile`, `.zshrc`, ...)
+Di solito questo si fa aggiungendo una riga di esportazione allo script di avvio della shell (`.profile`, `.zshrc`, ...)
 ```bash
 export PATH=$PATH:~/path/to/zig
 ```
-After you're done, either `source` your startup file or restart your shell.
+Quando hai finito, puoi eseguire `source` sul tuo script di avvio opppure riavviare la shell.
 
 
 
 
-## [Package managers]($heading.id('managers'))
+## [Gestori di pacchetti]($heading.id('managers'))
 ### Windows
-**WinGet**  
-Zig is available on [WinGet](https://github.com/microsoft/winget-pkgs/tree/master/manifests/z/zig/zig).
+**WinGet**
+Zig è disponibile su [WinGet](https://github.com/microsoft/winget-pkgs/tree/master/manifests/z/zig/zig).
 ```
 winget install -e --id zig.zig
 ```
 
-**Chocolatey**  
-Zig is available on [Chocolatey](https://chocolatey.org/packages/zig).
+**Chocolatey**
+Zig è disponibile su [Chocolatey](https://chocolatey.org/packages/zig).
 ```
 choco install zig
 ```
 
-**Scoop**  
-Zig is available on [Scoop](https://scoop.sh/#/apps?q=zig&id=7e124d6047c32d426e4143ab395d863fc9d6d491).
+**Scoop**
+Zig è disponibile su [Scoop](https://scoop.sh/#/apps?q=zig&id=7e124d6047c32d426e4143ab395d863fc9d6d491).
 ```
 scoop install zig
 ```
-Latest [dev build](https://scoop.sh/#/apps?q=zig&id=921df07e75042de645204262e784a17c2421944c):
+Ultima [dev build](https://scoop.sh/#/apps?q=zig&id=921df07e75042de645204262e784a17c2421944c):
 ```
 scoop bucket add versions
 scoop install versions/zig-dev
@@ -90,8 +91,8 @@ scoop install versions/zig-dev
 
 ### macOS
 
-**Homebrew**  
-Latest tagged release:
+**Homebrew**
+Rilascio taggato più recente:
 ```
 brew install zig
 ```
@@ -100,37 +101,37 @@ brew install zig
 ```
 port install zig
 ```
+
 ### Linux
-Zig is also present in many package managers for Linux. [Here](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)
-you can find an updated list but keep in mind that some packages might bundle outdated versions of Zig.
+Zig è presente anche in molti gestori di pacchetti per Linux. [Qui](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)
+puoi trovare una lista aggiornata, tuttavia alcuni gestori potrebbero fornire vecchie versioni Zig.
 
-## [Building from source]($heading.id('source'))
-[Here](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source) 
-you can find more information on how to build Zig from source for Linux, macOS and Windows.
+## [Compilare dal codice sorgente]($heading.id('source'))
+[Qui](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source)
+puoi trovare maggiori informazioni su come compilare Zig da sorgente per Linux, macOS e Windows.
 
-# Recommended tools
-## Syntax Highlighters and LSP
-All major text editors have syntax highlight support for Zig. 
-Some bundle it, some others require installing a plugin.  
+# Strumenti consigliati
+## Evidenziatori di sintassi e LSP
+Tutti i principali editor di codice supportano l'evidenziazione della sintassi di Zig.
+Alcuni la forniscono automaticamente, altri richiedono l'installazione di un plugin.
 
-If you're interested in a deeper integration between Zig and your editor, 
-checkout [zigtools/zls](https://github.com/zigtools/zls).
+Se vuoi una maggiore integrazione tra Zig e il tuo editor, dai un'occhiata a [zigtools/zls](https://github.com/zigtools/zls).
 
-If you're interested in what else is available, checkout the [Tools](tools) section.
+Se vuoi sapere cos'altro c'è a disposizione, dai un'occhiata alla sezione [Strumenti](tools).
 
 
-# Run Hello World
-If you completed the installation process correctly, you should now be able to invoke the Zig compiler from your shell.  
-Let's test this by creating your first Zig program!
+# Esegui Hello World
+Se hai completato il processo di installazione correttamente, ora dovresti poter richiamare il compilatore Zig dalla tua shell.
+Proviamolo subito creando il tuo primo programma in Zig!
 
-Navigate to your projects directory and run:
+Vai alla cartella che conterrà questo progetto ed esegui questi comandi:
 ```bash
 mkdir hello-world
 cd hello-world
 zig init
 ```
 
-This should output:
+Dovresti vedere questo output:
 ```
 info: created build.zig
 info: created build.zig.zon
@@ -139,21 +140,20 @@ info: created src/root.zig
 info: see `zig build --help` for a menu of options
 ```
 
-Running `zig build run` should then compile the executable and run it, ultimately resulting in:
+Eseguire `zig build run` dovrebbe compilare il tutto ed eseguirlo, mostrando questo:
 ```
 All your codebase are belong to us.
 Run `zig build test` to run the tests.
 ```
 
-Congratulations, you have a working Zig installation!  
+Congratulazioni, ora hai un'installazione di Zig funzionante!
 
-# Next steps
-**Check out other resources present in the [Learn](/learn) section**, make sure to find the Documentation for your version
-of Zig (note: nightly builds should use `master` docs) and consider giving [zig.guide](https://zig.guide) a read.
+# Prossimi passi
+**Dai un'occhiata alle altre risorse presenti nella sezione [Impara](/learn)**, assicurati di trovare la documentazione corretta per la tua versione di Zig (nota: per le build nightly usa la documentazione `master`) e fai un salto su [zig.guide](https://zig.guide).
 
-Zig is a young project and unfortunately we don't have yet the capacity to produce extensive documentation and learning
-materials for everything, so you should consider [joining one of the existing Zig communities](https://github.com/ziglang/zig/wiki/Community)
-to get help when you get stuck, as well as checking out initiatives like [Zig SHOWTIME](https://zig.show).
+Zig è un progetto relativamente giovane e purtroppo al momento non abbiamo ancora le risorse per produrre documentazione dettagliata e materiali didattici
+per ogni cosa, quindi ti consigliamo di [unirti a una delle comunità Zig](https://github.com/ziglang/zig/wiki/Community)
+per ricevere supporto quando non sai come risolvere un problema. Consigliamo inoltre di dare un'occhiata ad iniziative come [Zig SHOWTIME](https://zig.show).
 
-Finally, if you enjoy Zig and want to help speed up the development, [consider donating to the Zig Software Foundation](/zsf)
+Infine, se Zig ti piace e vuoi aiutare ad accelerare lo sviluppo del progetto, puoi [sostenerci con donazione alla Zig Software Foundation](/zsf)
 <img src="/heart.svg" style="vertical-align:middle; margin-right: 5px">.

--- a/content/it-IT/learn/index.smd
+++ b/content/it-IT/learn/index.smd
@@ -8,48 +8,47 @@
 },
 ---
 # [Impara]($section.id('learn'))
-Questa sezione contiene alcune risorse utili per iniziare ad imparare Zig.
+Questa sezione contiene alcune risorse utili per iniziare ad imparare Zig e la filosofia con cui è sviluppato.
 
 ## [Guide]($section.id('guides'))
-Questa sezione in futuro verra' integrata nella documentazione della libreria standard, ma nel frattempo e' disponibile qui.
+Questa sezione in futuro verrà integrata nella documentazione della libreria standard, ma nel frattempo è disponibile qui.
 
 - [Zig Build System](./build-system/)
 Introduzione al build system di Zig.
 
 ## Introduzione
-Pagine di introduzione a Zig, ognuna dedicata a programmatori con un background diverso.
+Pagine di introduzione a Zig, ognuna dedicata a programmatori con diversi livelli di esperienza.
 
-- [In-depth Overview](.overview/)  
-Una overview completa di Zig con una prospettiva da programmazione di sistemi.
-
-- [Why Zig When There is Already C++, D, and Rust?](.why_zig_rust_d_cpp/)  
-Una introduzione a Zig per programmatori esperti in  C++, D, o Rust. 
-
-- [Code Examples](.samples/)  
+- [Panoramica approfondita](./overview/)
+Una panoramica completa delle caratteristiche di Zig, con una prospettiva da programmazione di sistemi.
+- [Why Zig When There is Already C++, D, and Rust?](./why_zig_rust_d_cpp/)
+Un'introduzione a Zig per programmatori C++, D, o Rust.
+- [Code Examples](./samples/)
 Una lista di esempi di codice per farsi un'idea di Zig.
-
-- [Tools](.tools/)  
-Strumenti per sviluppatori.
+- [Strumenti](./tools/)
+Una lista di strumenti utili per facilitare la scrittura di codice in Zig.
 
 
 ## Inizia qui!
-- [Getting started](./getting-started/)  
+Se hai deciso di iniziare a programmare in Zig, questa guida ti aiuterà ad ottenere e configurare tutto il necessario.
 
-## Online learning resources
-- [zig.guide](https://zig.guide)  
-A structured introduction to Zig by [Sobeston](https://github.com/sobeston).
-- [Ziglings](https://ziglings.org)  
-Learn Zig by fixing tiny broken programs.
-- [Zig on Exercism](https://exercism.org/tracks/zig)
-Solve coding exercises and get mentored to develop fluency in Zig.
+- [Inizia qui](./getting-started)
+
+## Materiale didattico online
+- [zig.guide](https://zig.guide)
+Un'introduzione strutturata a Zig, creata da [Sobeston](https://github.com/sobeston).
+- [Ziglings](https://ziglings.org)
+Impara Zig risolvendo problemi in una serie di piccoli programmi.
+- [Zig su Exercism](https://exercism.org/tracks/zig)
+Completa degli esercizi di programmazione e ricevi supporto dagli esperti per padroneggiare Zig.
 - [Learning Zig](https://www.openmymind.net/learning_zig/)
-Short introduction to Zig well suited for developers coming from garbage-collected languages.
+Breve introduzione a Zig adatta a sviluppatori che vengono da linguaggi con gestione automatica della memoria (garbage-collection).
 
-## Relevant videos and blog posts
-- [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]  
-Video by [Andrew Kelley](https://andrewkelley.me) introducing Zig and its philosophy.
-- [Zig's New Relationship with LLVM](https://kristoff.it/blog/zig-new-relationship-llvm/)  
-A blog post about the work towards building the Zig self-hosted compiler, also featured in [an article by lwn.net](https://lwn.net/Articles/833400/).
+## Video e articoli consigliati
+- [Road to Zig 1.0](https://www.youtube.com/watch?v=Gv2I7qTux7g) [video]
+Video di [Andrew Kelley](https://andrewkelley.me) che presenta il linguaggio Zig e la sua filosofia.
+- [Zig's New Relationship with LLVM](https://kristoff.it/blog/zig-new-relationship-llvm/)
+Un articolo sulla realizzazione del compilatore self-hosted di Zig, citato anche in [un articolo  di lwn.net](https://lwn.net/Articles/833400/).
 
 
 

--- a/content/it-IT/learn/index.smd
+++ b/content/it-IT/learn/index.smd
@@ -49,21 +49,3 @@ Breve introduzione a Zig adatta a sviluppatori che vengono da linguaggi con gest
 Video di [Andrew Kelley](https://andrewkelley.me) che presenta il linguaggio Zig e la sua filosofia.
 - [Zig's New Relationship with LLVM](https://kristoff.it/blog/zig-new-relationship-llvm/)
 Un articolo sulla realizzazione del compilatore self-hosted di Zig, citato anche in [un articolo  di lwn.net](https://lwn.net/Articles/833400/).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/content/it-IT/learn/index.smd
+++ b/content/it-IT/learn/index.smd
@@ -21,9 +21,9 @@ Pagine di introduzione a Zig, ognuna dedicata a programmatori con diversi livell
 
 - [Panoramica approfondita](./overview/)
 Una panoramica completa delle caratteristiche di Zig, con una prospettiva da programmazione di sistemi.
-- [Why Zig When There is Already C++, D, and Rust?](./why_zig_rust_d_cpp/)
+- [Perchè Zig quando ci sono già C++, D e Rust?](./why_zig_rust_d_cpp/)
 Un'introduzione a Zig per programmatori C++, D, o Rust.
-- [Code Examples](./samples/)
+- [Esempi](./samples/)
 Una lista di esempi di codice per farsi un'idea di Zig.
 - [Strumenti](./tools/)
 Una lista di strumenti utili per facilitare la scrittura di codice in Zig.

--- a/content/it-IT/learn/overview.smd
+++ b/content/it-IT/learn/overview.smd
@@ -1,20 +1,20 @@
 ---
-.title = "Overview",
+.title = "Panoramica",
 .author = "",
 .date = @date("2024-08-07:00:00:00"),
 .layout = "page.shtml",
 .custom = {
-	"mobile_menu_title": "Overview",
+	"mobile_menu_title": "Panoramica",
 },
 ---
-# Feature Highlights
-## Small, simple language
+# Caratteristiche di rilievo
+## Un linguaggio piccolo, semplice
 
-Focus on debugging your application rather than debugging your programming language knowledge.
+Concentrati sul debuggare la tua applicazione, invece di debuggare la tua conoscenza del linguaggio di programmazione.
 
-Zig's entire syntax is specified with a [500-line PEG grammar file](https://ziglang.org/documentation/master/#Grammar).
+L'intera sintassi di Zig è specificata con un [file di grammatica PEG di 580 righe](https://ziglang.org/documentation/master/#Grammar).
 
-There is **no hidden control flow**, no hidden memory allocations, no preprocessor, and no macros. If Zig code doesn't look like it's jumping away to call a function, then it isn't. This means you can be sure that the following code calls only `foo()` and then `bar()`, and this is guaranteed without needing to know the types of anything:
+Non c'è **nessun controllo nascosto del flusso di esecuzione**, nessuna allocazione dinamica nascosta, nessun preprocessore e nessuna macro. Se vedi del codice Zig e non sembra che stia chiamando una funzione, allora non lo sta facendo. Questo significa che il seguente codice chiamerà sicuramente solo `foo()` e poi `bar()`, e questo è garantito anche senza conoscere i tipi di dato utilizzati:
 
 ```zig
 var a = b + c.d;
@@ -22,60 +22,60 @@ foo();
 bar();
 ```
 
-Examples of hidden control flow:
+Esempi di controllo nascosto del flusso di esecuzione:
 
-- D has `@property` functions, which are methods that you call with what looks like field access, so in the above example, `c.d` might call a function.
-- C++, D, and Rust have operator overloading, so the `+` operator might call a function.
-- C++, D, and Go have throw/catch exceptions, so `foo()` might throw an exception, and prevent `bar()` from being called.
+- D ha le funzioni `@property`, ovvero metodi che possono essere chiamati in un modo che sembra l'accesso a un attributo. Quindi, nell'esempio sopra, `c.d` potrebbe chiamare una funzione.
+- C++, D e Rust supportano l'overload degli operatori, quindi l'operatore `+` potrebbe chiamare una funzione.
+- C++, D e Go hanno eccezioni throw/catch, quindi `foo()` potrebbe lanciare un'eccezione, e impedire l'esecuzione di `bar()`.
 
- Zig promotes code maintenance and readability by making all control flow managed exclusively with language keywords and function calls.
+Zig promuove la manutenibilità e leggibilità del codice permettendo di gestire il flusso di esecuzione esclusivamente con le parole chiave del linguaggio e le chiamate di funzioni.
 
-## Performance and Safety: Choose Two
+## Prestazioni e sicurezza: scegline due
 
-Zig has four [build modes](https://ziglang.org/documentation/master/#Build-Mode), and they can all be mixed and matched all the way down to [scope granularity](https://ziglang.org/documentation/master/#setRuntimeSafety).
+Zig ha quattro [modalità di build](https://ziglang.org/documentation/master/#Build-Mode), che possono essere mescolate tra di loro e specificare la modalità di qualunque [blocco o ambito di visibilità](https://ziglang.org/documentation/master/#setRuntimeSafety).
 
-| Parameter | [Debug](/documentation/master/#Debug) | [ReleaseSafe](/documentation/master/#ReleaseSafe) | [ReleaseFast](/documentation/master/#ReleaseFast) | [ReleaseSmall](/documentation/master/#ReleaseSmall) |
+| Parametro | [Debug](/documentation/master/#Debug) | [ReleaseSafe](/documentation/master/#ReleaseSafe) | [ReleaseFast](/documentation/master/#ReleaseFast) | [ReleaseSmall](/documentation/master/#ReleaseSmall) |
 |-----------|-------|-------------|-------------|--------------|
-Optimizations - improve speed, harm debugging, harm compile time | | -O3 | -O3| -Os |
-Runtime Safety Checks - harm speed, harm size, crash instead of undefined behavior | On | On | | |
+Ottimizzazioni - migliora prestazioni, peggiora debug e tempo di compilazione | | -O3 | -O3| -Os |
+Controlli di sicurezza a runtime - peggiora prestazioni e dimensioni, crash invece di comportamenti non definiti (UB) | On | On | | |
 
-Here is what [Integer Overflow](https://ziglang.org/documentation/master/#Integer-Overflow) looks like at compile time, regardless of the build mode:
+Ecco come l'[overflow di interi](https://ziglang.org/documentation/master/#Integer-Overflow) appare in fase di compilazione, a prescindere dalla modalità di build:
 
 []($code.language('=html').buildAsset('features/1-integer-overflow.zig'))
 
-Here is what it looks like at runtime, in safety-checked builds:
+Ecco come appare durante l'esecuzione, nelle build con controlli di sicurezza attivi:
 
 []($code.language('=html').buildAsset('features/2-integer-overflow-runtime.zig'))
 
 
-Those [stack traces work on all targets](#stack-traces-on-all-targets), including [freestanding](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html).
+Questi [stack trace funzionano su tutte le piattaforme](#stack-traces-on-all-targets), incluse quelle [freestanding](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html).
 
-With Zig one can rely on a safety-enabled build mode, and selectively disable safety at the performance bottlenecks. For example the previous example could be modified like this:
+Con Zig puoi fare affidamento sulla modalità di build sicura, e disattivare selettivamente alcuni dei controlli di sicurezza se e dove sono necessarie maggiori prestazioni. Per esempio, il codice mostrato nell'esempio precedente può essere modificato in questo modo:
 
 []($code.language('=html').buildAsset('features/3-undefined-behavior.zig'))
 
-Zig uses [undefined behavior](https://ziglang.org/documentation/master/#Undefined-Behavior) as a razor sharp tool for both bug prevention and performance enhancement.
+Zig usa i [comportamenti non definiti](https://ziglang.org/documentation/master/#Undefined-Behavior) come strumento estremamente preciso per prevenire bug e migliorare le prestazioni.
 
-Speaking of performance, Zig is faster than C.
+A proposito di prestazioni, Zig è più veloce rispetto a C.
 
-- The reference implementation uses LLVM as a backend for state of the art optimizations.
-- What other projects call "Link Time Optimization" Zig does automatically.
-- For native targets, advanced CPU features are enabled (-march=native), thanks to the fact that [Cross-compiling is a first-class use case](#cross-compiling-is-a-first-class-use-case).
-- Carefully chosen undefined behavior. For example, in Zig both signed and unsigned integers have undefined behavior on overflow, contrasted to only signed integers in C. This [facilitates optimizations that are not available in C](https://godbolt.org/z/n_nLEU).
-- Zig directly exposes a [SIMD vector type](https://ziglang.org/documentation/master/#Vectors), making it easy to write portable vectorized code.
+- L'implementazione di riferimento usa LLVM come backend per applicare lo stato dell'arte delle ottimizzazioni.
+- Ciò che altri progetti chiamano "Link Time Optimization", Zig lo fa in automatico.
+- Per la piattaforma native vengono abilitate le funzioni avanzate della CPU (`-march=native`), grazie al fatto che [la cross-compilazione è un caso d'uso primario](#cross-compiling-is-a-first-class-use-case).
+- Comportamenti non definiti (UB) accuratamente selezionati. Per esempio, in Zig sia gli interi con segno che quelli unsigned hanno comportamenti non definiti in caso di overflow, in contrasto a C dove ciò è vero solo per gli interi con segno. Questo [facilita delle ottimizzazioni non disponibili in C](https://godbolt.org/z/n_nLEU).
+- Zig espone direttamente un [tipo di vettore SIMD](https://ziglang.org/documentation/master/#Vectors), che rende semplice scrivere codice vettorizzato portabile.
 
-Please note that Zig is not a fully safe language. For those interested in following Zig's safety story, subscribe to these issues:
+Zig non è un linguaggio completamente sicuro. Per chi fosse interessato ad approfondire il tema della sicurezza in Zig, tieni d'occhio le seguenti discussioni:
 
 - [enumerate all kinds of undefined behavior, even that which cannot be safety-checked](https://github.com/ziglang/zig/issues/1966)
 - [make Debug and ReleaseSafe modes fully safe](https://github.com/ziglang/zig/issues/2301)
 
-## Zig competes with C instead of depending on it
+## Zig compete con C invece di dipendere da C
 
-The Zig Standard Library integrates with libc, but does not depend on it. Here's Hello World:
+La libreria standard di Zig comunica con libc, ma può farne a meno. Ecco un "hello world":
 
 []($code.language('=html').buildAsset('features/4-hello.zig'))
 
-When compiled with `-O ReleaseSmall`, debug symbols stripped, single-threaded mode, this produces a 9.8 KiB static executable for the x86_64-linux target:
+Quando compilato con `-O ReleaseSmall`, senza simboli di debug, in modalità single-thread, il seguente codice produce un eseguibile statico di 9.8 KiB per la piattaforma x86_64-linux:
 ```
 $ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded
 $ wc -c hello
@@ -84,7 +84,7 @@ $ ldd hello
   not a dynamic executable
 ```
 
-A Windows build is even smaller, coming out to 4096 bytes:
+Una build per Windows è persino più piccola, occupando solo 4096 byte:
 ```
 $ zig build-exe hello.zig -O ReleaseSmall -fstrip -fsingle-threaded -target x86_64-windows
 $ wc -c hello.exe
@@ -93,121 +93,121 @@ $ file hello.exe
 hello.exe: PE32+ executable (console) x86-64, for MS Windows
 ```
 
-## Order independent top level declarations
+## Dichiarazioni di alto livello indipendenti dall'ordine
 
-Top level declarations such as global variables are order-independent and lazily analyzed. The initialization values of global variables are [evaluated at compile-time](#compile-time-reflection-and-compile-time-code-execution).
+Le dichiarazioni di alto livello come le variabili globali sono visibili indipendentemente dall'ordine con cui appaiono nel codice, e sono analizzate in modo lazy. I valori usati per inizializzare le variabili globali sono [valutati in fase di compilazione](#compile-time-reflection-and-compile-time-code-execution).
 
 []($code.language('=html').buildAsset('features/5-global-variables.zig'))
 
-## Optional type instead of null pointers
+## Tipi opzionali invece di puntatori nulli
 
-In other programming languages, null references are the source of many runtime exceptions, and even stand accused of being [the worst mistake of computer science](https://www.lucidchart.com/techblog/2015/08/31/the-worst-mistake-of-computer-science/).
+In altri linguaggi di programmazione, i riferimenti nulli sono la causa di molte eccezioni a runtime, e sono persino accusati di essere [il più grave errore delle scienze informatiche](https://www.lucidchart.com/techblog/2015/08/31/the-worst-mistake-of-computer-science/).
 
-Unadorned Zig pointers cannot be null:
+In Zig, di base i puntatori non possono essere nulli:
 
 []($code.language('=html').buildAsset('features/6-null-to-ptr.zig'))
 
-However any type can be made into an [optional type](https://ziglang.org/documentation/master/#Optionals) by prefixing it with ?:
+Ciononostante, ogni tipo di dato può essere reso un [tipo opzionale](https://ziglang.org/documentation/master/#Optionals) anteponendo un `?`:
 
 []($code.language('=html').buildAsset('features/7-optional-syntax.zig'))
 
-To unwrap an optional value, one can use `orelse` to provide a default value:
+Per estrarre il valore da un tipo opzionale (unwrapping), si può usare `orelse` per fornire un valore di default:
 
 []($code.language('=html').buildAsset('features/8-optional-orelse.zig'))
 
-Another option is to use if:
+In alternativa si può usare un `if`:
 
 []($code.language('=html').buildAsset('features/9-optional-if.zig'))
 
- The same syntax works with [while](https://ziglang.org/documentation/master/#while):
+La stessa sintassi funziona con [while](https://ziglang.org/documentation/master/#while):
 
 []($code.language('=html').buildAsset('features/10-optional-while.zig'))
 
-## Manual memory management
+## Gestione manuale della memoria
 
-A library written in Zig is eligible to be used anywhere:
+Una libreria scritta in Zig è adatta a qualunque contesto:
 
-- [Desktop applications](https://github.com/TM35-Metronome/)
-- Low latency servers
-- [Operating System kernels](https://github.com/AndreaOrru/zen)
-- [Embedded devices](https://github.com/skyfex/zig-nrf-demo/)
-- Real-time software, e.g. live performances, airplanes, pacemakers
-- [In web browsers or other plugins with WebAssembly](https://shritesh.github.io/zigfmt-web/)
-- By other programming languages, using the C ABI
+- [Applicazioni desktop](https://github.com/TM35-Metronome/)
+- Server a bassa latenza
+- [Kernel di sistemi operativi](https://github.com/AndreaOrru/zen)
+- [Sistemi embedded](https://github.com/skyfex/zig-nrf-demo/)
+- Software real-time, come performance live, aeroplani, pacemaker
+- [In browser web o plugin con WebAssembly](https://shritesh.github.io/zigfmt-web/)
+- Utilizzo da altri linguaggi di programmazione, mediante l'ABI di C
 
-In order to accomplish this, Zig programmers must manage their own memory, and must handle memory allocation failure.
+Per permettere questo risultato, i programmatori Zig devono gestire manualmente la memoria, e devono gestire gli errori di allocazione.
 
-This is true of the Zig Standard Library as well. Any functions that need to allocate memory accept an allocator parameter. As a result, the Zig Standard Library can be used even for the freestanding target.
+Questo vale anche per la libreria standard di Zig. Ogni funzione che necessita di allocazioni dinamiche accetta come parametro un allocatore. Per questo motivo, la libreria standard di Zig può essere utilizzata anche su piattaforme hardware.
 
-In addition to [A fresh take on error handling](#a-fresh-take-on-error-handling), Zig provides [defer](https://ziglang.org/documentation/master/#defer) and [errdefer](https://ziglang.org/documentation/master/#errdefer) to make all resource management - not only memory - simple and easily verifiable.
+In aggiunta a [un nuovo approccio alla gestione degli errori](#a-fresh-take-on-error-handling), Zig fornisce [defer](https://ziglang.org/documentation/master/#defer) e [errdefer](https://ziglang.org/documentation/master/#errdefer) per rendere tutta la gestione di risorse - non solo la memoria - semplice e facilmente verificabile.
 
-For an example of `defer`, see [Integration with C libraries without FFI/bindings](#integration-with-c-libraries-without-ffibindings). Here is an example of using `errdefer`:
+Per un esempio di `defer`, vedi la sezione [Integrazione con librerie C senza FFI/binding](#integration-with-c-libraries-without-ffibindings). Ecco un esempio di utilizzo di `errdefer`:
 []($code.language('=html').buildAsset('features/11-errdefer.zig'))
 
 
-## A fresh take on error handling
+## Un nuovo approccio alla gestione degli errori
 
-Errors are values, and may not be ignored:
+Gli errori sono valori, e non possono essere ignorati:
 
 []($code.language('=html').buildAsset('features/12-errors-as-values.zig'))
 
-Errors can be handled with [catch](https://ziglang.org/documentation/master/#catch):
+Gli errori possono essere gestiti con [catch](https://ziglang.org/documentation/master/#catch):
 
 []($code.language('=html').buildAsset('features/13-errors-catch.zig'))
 
-The keyword [try](https://ziglang.org/documentation/master/#try) is a shortcut for `catch |err| return err`:
+La parola chiave [try](https://ziglang.org/documentation/master/#try) è un'abbreviazione di `catch |err| return err`:
 
 []($code.language('=html').buildAsset('features/14-errors-try.zig'))
 
-Note that is an [Error Return Trace](https://ziglang.org/documentation/master/#Error-Return-Traces), not a [stack trace](#stack-traces-on-all-targets). The code did not pay the price of unwinding the stack to come up with that trace.
+Nota che questa è un [Error Return Trace](https://ziglang.org/documentation/master/#Error-Return-Traces), non uno [stack trace](#stack-traces-on-all-targets). Il codice non ha dovuto pagare il prezzo dell'unwinding dello stack per ottenere queste informazioni.
 
-The [switch](https://ziglang.org/documentation/master/#switch) keyword used on an error ensures that all possible errors are handled:
+La parola chiave [switch](https://ziglang.org/documentation/master/#switch) usata su un errore garantisce che tutti i possibili errori siano gestiti:
 
 []($code.language('=html').buildAsset('features/15-errors-switch.zig'))
 
-The keyword [unreachable](https://ziglang.org/documentation/master/#unreachable) is used to assert that no errors will occur:
+La parola chiave [unreachable](https://ziglang.org/documentation/master/#unreachable) viene usata per dichiarare che non si verificherà alcun errore:
 
 []($code.language('=html').buildAsset('features/16-unreachable.zig'))
 
-This invokes [undefined behavior](#performance-and-safety-choose-two) in the unsafe build modes, so be sure to use it only when success is guaranteed.
+Nelle build senza controlli di sicurezza, questo risulterà un [comportamento non definito](#performance-and-safety-choose-two), quindi assicurati di usare `unreachable` solo quando hai la certezza che un'operazione avrà successo.
 
-### Stack traces on all targets
+### Stack trace su ogni piattaforma
 
-The stack traces and [error return traces](https://ziglang.org/documentation/master/#Error-Return-Traces) shown on this page work on all [Tier 1 Support](#tier-1-support) and some [Tier 2 Support](#tier-2-support) targets. [Even freestanding](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html)!
+I stack trace e gli [error return trace](https://ziglang.org/documentation/master/#Error-Return-Traces) mostrati in questa pagina funzionano su tutte le piattaforme con [supporto Tier 1](#tier-1-support) e alcune con [supporto Tier 2](#tier-2-support). [Persino piattaforme hardware](https://andrewkelley.me/post/zig-stack-traces-kernel-panic-bare-bones-os.html)!
 
-In addition, the standard library has the ability to capture a stack trace at any point and then dump it to standard error later:
+Inoltre, la libreria standard permette di catturare uno stack trace in qualunque punto del programma e inviarlo al canale *standard error* in un secondo momento:
 
 []($code.language('=html').buildAsset('features/17-stack-traces.zig'))
 
-You can see this technique being used in the ongoing [GeneralPurposeDebugAllocator project](https://github.com/andrewrk/zig-general-purpose-allocator/#current-status).
+Puoi vedere un utilizzo di questa tecnica nel progetto [GeneralPurposeDebugAllocator](https://github.com/andrewrk/zig-general-purpose-allocator/#current-status).
 
-## Generic data structures and functions
+## Strutture dati generiche e funzioni
 
-Types are values that must be known at compile-time:
+I tipi di dato sono valori che devono essere conosciuti in fase di compilazione.
 
 []($code.language('=html').buildAsset('features/18-types.zig'))
 
-A generic data structure is simply a function that returns a `type`:
+Una struttura dati generica è semplicemente una funzione che restituisce un valore di tipo `type`:
 
 []($code.language('=html').buildAsset('features/19-generics.zig'))
 
-## Compile-time reflection and compile-time code execution
+## Riflessione ed esecuzione in fase di compilazione
 
-The [@typeInfo](https://ziglang.org/documentation/master/#typeInfo) builtin function provides reflection:
+La funzione *builtin* [@typeInfo](https://ziglang.org/documentation/master/#typeInfo) permette la riflessione:
 
 []($code.language('=html').buildAsset('features/20-reflection.zig'))
 
-The Zig Standard Library uses this technique to implement formatted printing. Despite being a [Small, simple language](#small-simple-language), Zig's formatted printing is implemented entirely in Zig. Meanwhile, in C, compile errors for printf are hard-coded into the compiler. Similarly, in Rust, the formatted printing macro is hard-coded into the compiler.
+La libreria standard di Zig usa questa tecnica per implementare l'output di stringhe formattate. Nonostante il [linguaggio sia piccolo e semplice](#small-simple-language), questa funzione è implementata interamente in Zig. Nel frattempo, in C, gli errori di compilazione per `printf` sono *hard-coded*, scritti direttamente nel compilatore. Similmente, in Rust, la funzione equivalente è una macro implementata direttamente nel compilatore.
 
-Zig can also evaluate functions and blocks of code at compile-time. In some contexts, such as global variable initializations, the expression is implicitly evaluated at compile-time. Otherwise, one can explicitly evaluate code at compile-time with the [comptime](https://ziglang.org/documentation/master/#comptime) keyword. This can be especially powerful when combined with assertions:
+Zig può anche valutare funzioni e blocchi di codice in fase di compilazione. In alcuni contesti, come l'inizializzazione di variabili globali, le espressioni sono implicitamente valutate in fase di compilazione. In alternativa, la parola chiave [comptime](https://ziglang.org/documentation/master/#comptime) permette di eseguire esplicitamente una porzione di codice in fase di compilazione. Può essere estremamente utile se combinato con le asserzioni:
 
 []($code.language('=html').buildAsset('features/21-comptime.zig'))
 
-## Integration with C libraries without FFI/bindings
+## Integrazione con librerie C senza FFI/bindings
 
-[@cImport](https://ziglang.org/documentation/master/#cImport) directly imports types, variables, functions, and simple macros for use in Zig. It even translates inline functions from C into Zig.
+[@cImport](https://ziglang.org/documentation/master/#cImport) importa direttamente tipi, variabili, funzioni e macro semplici, permettendone l'utilizzo in Zig. Traduce persino le funzioni `inline` da C a Zig.
 
-Here is an example of emitting a sine wave using [libsoundio](http://libsound.io/):
+Il seguente esempio emette un'onda sonora sinusoidale utilizzando [libsoundio](http://libsound.io/):
 
 <u>sine.zig</u>
 []($code.language('=html').buildAsset('features/22-sine-wave.zig'))
@@ -219,13 +219,13 @@ Output device: Built-in Audio Analog Stereo
 ^C
 ```
 
-[This Zig code is significantly simpler than the equivalent C code](https://gist.github.com/andrewrk/d285c8f912169329e5e28c3d0a63c1d8), as well as having more safety protections, and all this is accomplished by directly importing the C header file - no API bindings.
+[Questo codice Zig è molto più semplice dell'equivalente C](https://gist.github.com/andrewrk/d285c8f912169329e5e28c3d0a63c1d8), oltre ad avere migliori controlli sugli errori, e tutto questo è stato ottenuto importando direttamente un file di intestazione C - senza binding delle API.
 
-*Zig is better at using C libraries than C is at using C libraries.*
+*Zig usa le librerie C meglio di quanto C usa le librerie C.*
 
-### Zig is also a C compiler
+### Zig è anche un compilatore C
 
-Here's an example of Zig building some C code:
+Ecco un esempio di come Zig compila del codice C:
 
 <u>hello.c</u>
 ```c
@@ -243,13 +243,13 @@ $ ./hello
 Hello world
 ```
 
-You can use `--verbose-cc` to see what C compiler command this executed:
+Puoi usare `--verbose-cc` per vedere il comando eseguito dal compilatore C:
 ```
 $ zig build-exe hello.c --library c --verbose-cc
 zig cc -MD -MV -MF .zig-cache/tmp/42zL6fBH8fSo-hello.o.d -nostdinc -fno-spell-checking -isystem /home/andy/dev/zig/build/lib/zig/include -isystem /home/andy/dev/zig/build/lib/zig/libc/include/x86_64-linux-gnu -isystem /home/andy/dev/zig/build/lib/zig/libc/include/generic-glibc -isystem /home/andy/dev/zig/build/lib/zig/libc/include/x86_64-linux-any -isystem /home/andy/dev/zig/build/lib/zig/libc/include/any-linux-any -march=native -g -fstack-protector-strong --param ssp-buffer-size=4 -fno-omit-frame-pointer -o .zig-cache/tmp/42zL6fBH8fSo-hello.o -c hello.c -fPIC
 ```
 
-Note that if you run the command again, there is no output, and it finishes instantly:
+Nota che eseguendo di nuovo il comando, non c'è alcun output, e la compilazione è istantanea:
 ```
 $ time zig build-exe hello.c --library c --verbose-cc
 
@@ -258,28 +258,28 @@ user	0m0.018s
 sys	0m0.009s
 ```
 
-This is thanks to [Build Artifact Caching](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching). Zig automatically parses the .d file uses a robust caching system to avoid duplicating work.
+Questo è possibile grazie al [caching dei risultati di compilazione](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching). Zig legge automaticamente il file `.d` e usa un robusto sistema di caching per evitare di rifare lavoro non necessario.
 
-Not only can Zig compile C code, but there is a very good reason to use Zig as a C compiler: [Zig ships with libc](#zig-ships-with-libc).
+Non solo Zig può compilare codice C, ma ci sono anche ottime ragioni per usare Zig come compilatore C: [Zig integra libc](#zig-ships-with-libc).
 
-### Export functions, variables, and types for C code to depend on
+### Esporta funzioni, variabili e tipi per permetterne l'uso a C
 
-One of the primary use cases for Zig is exporting a library with the C ABI for other programming languages to call into. The `export` keyword in front of functions, variables, and types causes them to be part of the library API:
+Uno dei casi d'uso primari di Zig è esportare una libreria con l'ABI di C che possa essere richiamata da altri linguaggi di programmazione. La parola chiave `export` anteposta a funzioni, variabili e tipi di dato, li rende parte dell'API della libreria:
 
 <u>mathtest.zig</u>
 []($code.language('=html').buildAsset('features/23-math-test.zig'))
 
-To make a static library:
+Per creare una libreria statica:
 ```
 $ zig build-lib mathtest.zig
 ```
 
-To make a shared library:
+Per creare una libreria dinamica/condivisa:
 ```
 $ zig build-lib mathtest.zig -dynamic
 ```
 
-Here is an example with the [Zig Build System](#zig-build-system):
+Un esempio con il [sistema di build di Zig](#zig-build-system):
 
 <u>test.c</u>
 ```c
@@ -301,13 +301,13 @@ $ zig build test
 1379
 ```
 
-## Cross-compiling is a first-class use case
+## la cross-compilazione è un caso d'uso primario
 
-Zig can build for any of the targets from the [Support Table](#support-table) with [Tier 3 Support](#tier-3-support) or better. No "cross toolchain" needs to be installed or anything like that. Here's a native Hello World:
+Zig può compilare per ognuna delle piattaforme indicate nella [tabella di supporto](#support-table) come [Tier 3](#tier-3-support) o superiore. Non è necessario installare alcuna "cross toolchain" o niente di simile. Ecco un Hello World nativo:
 
 []($code.language('=html').buildAsset('features/4-hello.zig'))
 
-Now to build it for x86_64-windows, x86_64-macos, and aarch64-linux:
+Ora lo compiliamo per `x86_64-windows`, `x86_64-macos` e `aarch64-linux`:
 ```
 $ zig build-exe hello.zig -target x86_64-windows
 $ file hello.exe
@@ -320,11 +320,11 @@ $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-This works on any [Tier 3](#tier-3-support)+ target, for any [Tier 3](#tier-3-support)+ target.
+Questo funziona da qualunque piattaforma [Tier 3](#tier-3-support)+, verso qualunque piattaforma [Tier 3](#tier-3-support)+.
 
-### Zig ships with libc
+### Zig integra libc
 
-You can find the available libc targets with `zig targets`:
+Puoi vedere la lista delle piattaforme supportate da `libc` con il comando `zig targets`:
 ```
 ...
  "libc": [
@@ -377,9 +377,9 @@ You can find the available libc targets with `zig targets`:
  ],
  ```
 
-What this means is that `--library c` for these targets *does not depend on any system files*!
+Questo significa che `--library c` su queste piattaforme *non dipende da alcun file di sistema*!
 
-Let's look at that [C hello world example](#zig-is-also-a-c-compiler) again:
+Diamo nuovamente un'occhiata a quel [Hello World in C](#zig-is-also-a-c-compiler):
 ```
 $ zig build-exe hello.c --library c
 $ ./hello
@@ -394,7 +394,7 @@ $ ldd ./hello
 	/lib/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007fc4b6672000)
 ```
 
-[glibc](https://www.gnu.org/software/libc/) does not support building statically, but [musl](https://www.musl-libc.org/) does:
+[glibc](https://www.gnu.org/software/libc/) non supporta la creazione di binari statici, ma [musl](https://www.musl-libc.org/) lo può fare:
 ```
 $ zig build-exe hello.c --library c -target x86_64-linux-musl
 $ ./hello
@@ -403,32 +403,32 @@ $ ldd hello
   not a dynamic executable
 ```
 
-In this example, Zig built musl libc from source and then linked against it. The build of musl libc for x86_64-linux remains available thanks to the [caching system](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching), so any time this libc is needed again it will be available instantly.
+In questo esempio, Zig ha compilato `musl libc` da sorgente e poi ha linkato ad esso. La build di `musl libc` per `x86_64-linux` rimane disponibile grazie al [sistema di cache](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching), quindi ogni volta che ci sarà nuovamente bisogno di questo `libc` sarà disponibile istantaneamente.
 
-This means that this functionality is available on any platform. Windows and macOS users can build Zig and C code, and link against libc, for any of the targets listed above. Similarly code can be cross compiled for other architectures:
+Questo significa che questa funzionalità è disponibile su ogni piattaforma. Gli utenti Windows e macOS possono compilare codice Zig e C, e linkare `libc`, per ognuno dei target elencati sopra. Allo stesso modo, è possibile cross-compilare del codice per altre architetture:
 ```
 $ zig build-exe hello.c --library c -target aarch64-linux-gnu
 $ file hello
 hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
 ```
 
-In some ways, Zig is a better C compiler than C compilers!
+In un certo senso, Zig compila C meglio dei compilatori C!
 
-This functionality is more than bundling a cross-compilation toolchain along with Zig. For example, the total size of libc headers that Zig ships is 22 MiB uncompressed. Meanwhile, the headers for musl libc + linux headers on x86_64 alone are 8 MiB, and for glibc are 3.1 MiB (glibc is missing the linux headers), yet Zig currently ships with 40 libcs. With a naive bundling that would be 444 MiB. However, thanks to this [process_headers tool](https://github.com/ziglang/zig/blob/0.4.0/libc/process_headers.zig), and some [good old manual labor](https://github.com/ziglang/zig/wiki/Updating-libc), Zig binary tarballs remain roughly 30 MiB total, despite supporting libc for all these targets, as well as compiler-rt, libunwind, and libcxx, and despite being a clang-compatible C compiler. For comparison, the Windows binary build of clang 8.0.0 itself from llvm.org is 132 MiB.
+Questa funzionalità è più avanzata rispetto alla sola integrazione di uno strumento di cross-compilazione in Zig. Per esempio, la dimensione totale non compressa delle intestazioni libc incluse in Zig è 22 MiB. Allo stesso tempo, gli header di musl libc + header di linux per la sola architettura x86_64 sono in totale 8 MiB, e per glibc sono 3.1 MiB (a glibc mancano gli header linux), eppure Zig al momento include 40 versioni di libc. Includendoli così come sono, sarebbero 444 MiB. Però, grazie a questo [strumento di elaborazione header](https://github.com/ziglang/zig/blob/0.4.0/libc/process_headers.zig), e del [buon vecchio olio di gomito](https://github.com/ziglang/zig/wiki/Updating-libc), gli archivi scaricabili di Zig rimangono a circa 50 Mib totali, nonostante supportino `libc` su tutti questi target, oltre a compiler-rt, libunwind e libcxx, e nonostante sia un compilator  compatibile con Clang. Per fare un confronto, la build per Windows dello stesso Clang (v8.0.0) presa da llvm.org occupa 132 MiB.
 
-Note that only the [Tier 1 Support](#tier-1-support) targets have been thoroughly tested. It is planned to [add more libcs](https://github.com/ziglang/zig/issues/514) (including for Windows), and to [add test coverage for building against all the libcs](https://github.com/ziglang/zig/issues/2058).
+Nota che solo i target con supporto [Tier 1](#tier-1-support) sono stati testati in modo esaustivo. Abbiamo già in programma di [aggiungere altri libc](https://github.com/ziglang/zig/issues/514) (anche per Windows), e di [aggiungere copertura dei test per la compilazione con tutte le versioni di libc](https://github.com/ziglang/zig/issues/2058).
 
 It's [planned to have a Zig Package Manager](https://github.com/ziglang/zig/issues/943), but it's not done yet. One of the things that will be possible is to create a package for C libraries. This will make the [Zig Build System](#zig-build-system) attractive for Zig programmers and C programmers alike.
 
-## Zig Build System
+## Il build system di Zig
 
-Zig comes with a build system, so you don't need make, cmake, or anything like that.
+Zig ha un proprio sistema di build, quindi non servono `make`, `cmake` o simili.
 ```
 $ zig init-exe
 Created build.zig
 Created src/main.zig
 
-Next, try `zig build --help` or `zig build run`
+Ora prova `zig build --help` oppure `zig build run`
 ```
 
 <u>src/main.zig</u>
@@ -439,7 +439,7 @@ Next, try `zig build --help` or `zig build run`
 []($code.language('=html').buildAsset('features/26-build.zig'))
 
 
-Let's have a look at that `--help` menu.
+Diamo un'occhiata a quel menu `--help`:
 ```
 $ zig build --help
 Usage: zig build [steps] [options]
@@ -475,17 +475,17 @@ Advanced Options:
   --verbose-llvm-cpu-features Enable compiler debug output for LLVM CPU features
 ```
 
-You can see that one of the available steps is run.
+Come vedi uno degli step diponibili è `run`:
 ```
 $ zig build run
 All your base are belong to us.
 ```
 
-Here are some example build scripts:
+Ecco alcuni esempi di build script:
 
-- [Build script of OpenGL Tetris game](https://github.com/andrewrk/tetris/blob/master/build.zig)
-- [Build script of bare metal Raspberry Pi 3 arcade game](https://github.com/andrewrk/clashos/blob/master/build.zig)
-- [Build script of self-hosted Zig compiler](https://github.com/ziglang/zig/blob/master/build.zig)
+- [Build script di un gioco Tetris in OpenGL](https://github.com/andrewrk/tetris/blob/master/build.zig)
+- [Build script di un gioco arcade per Raspberry Pi 3 (solo hardware)](https://github.com/andrewrk/clashos/blob/master/build.zig)
+- [Build script del compilatore self-hosted di Zig](https://github.com/ziglang/zig/blob/master/build.zig)
 
 ## Concurrency via Async Functions
 
@@ -497,23 +497,24 @@ Zig infers whether a function is async, and allows `async`/`await` on non-async 
 
 The Zig Standard Library implements an event loop that multiplexes async functions onto a thread pool for M:N concurrency. Multithreading safety and race detection are areas of active research.
 
-## Wide range of targets supported
+## Vasta gamma di piattaforme supportate
 
-Zig uses a "support tier" system to communicate the level of support for different targets.
+Zig usa un sistema "grado di supporto" per indicare fino a che punto Zig è supportato su una certa piattaforma.
 
-[Support Table as of Zig 0.11.0](https://ziglang.org/download/0.11.0/release-notes.html#Support-Table)
+[Tabella di supporto aggiornata a Zig 0.11.0](https://ziglang.org/download/0.11.0/release-notes.html#Support-Table)
 
-## Friendly toward package maintainers
+## Semplifica la vita ai mantenitori di pacchetti
 
-The reference Zig compiler is not completely self-hosted yet, but no matter what, [it will remain exactly 3 steps](https://github.com/ziglang/zig/issues/853) to go from having a system C++ compiler to having a fully self-hosted Zig compiler for any target. As Maya Rashish notes, [porting Zig to other platforms is fun and speedy](http://coypu.sdf.org/porting-zig.html).
+The reference Zig compiler is not completely self-hosted yet, but no matter what, [it will remain exactly 3 steps](https://github.com/ziglang/zig/issues/853) to go from having a system C++ compiler to having a fully self-hosted Zig compiler for any target.
+Come fa notare Maya Rashish, [rendere Zig disponibile su altre piattaforme è divertente e richiede poco tempo](http://coypu.sdf.org/porting-zig.html).
 
-Non-debug [build modes](https://ziglang.org/documentation/master/#Build-Mode) are reproducible/deterministic.
+Ad eccezione della modalità debug, le [modalità di build](https://ziglang.org/documentation/master/#Build-Mode) sono riproducibili/deterministiche.
 
-There is a [JSON version of the download page](https://ziglang.org/download/index.json).
+C'è una [versione JSON della pagina dei download](https://ziglang.org/download/index.json).
 
-Several members of the Zig team have experience maintaining packages.
+Diversi membri del team di Zig hanno esperienza nel mentenimento di pacchetti.
 
-- [Daurnimator](https://github.com/daurnimator) maintains the [Arch Linux package](https://archlinux.org/packages/extra/x86_64/zig/)
-- [Marc Tiehuis](https://tiehuis.github.io/) maintains the Visual Studio Code package.
-- [Andrew Kelley](https://andrewkelley.me/) spent a year or so doing [Debian and Ubuntu packaging](https://qa.debian.org/developer.php?login=superjoe30%40gmail.com&comaint=yes), and casually contributes to [nixpkgs](https://github.com/NixOS/nixpkgs/).
-- [Jeff Fowler](https://blog.jfo.click/) maintains the Homebrew package and started the [Sublime package](https://github.com/ziglang/sublime-zig-language) (now maintained by [emekoi](https://github.com/emekoi)).
+- [Daurnimator](https://github.com/daurnimator) mantiene il [pacchetto per Arch Linux](https://archlinux.org/packages/extra/x86_64/zig/).
+- [Marc Tiehuis](https://tiehuis.github.io/) mantiene il pacchetto per Visual Studio Code.
+- [Andrew Kelley](https://andrewkelley.me/) ha passato circa un anno gestendo [pacchetti per Debian e Ubuntu](https://qa.debian.org/developer.php?login=superjoe30%40gmail.com&comaint=yes), e ogni tanto contribuisce a [nixpkgs](https://github.com/NixOS/nixpkgs/).
+- [Jeff Fowler](https://blog.jfo.click/) mantiene il pacchetto Homebrew e ha creato il [pacchetto Sublime Text](https://github.com/ziglang/sublime-zig-language) (ora mantenuto da [emekoi](https://github.com/emekoi)).

--- a/content/it-IT/learn/samples.smd
+++ b/content/it-IT/learn/samples.smd
@@ -1,43 +1,44 @@
 ---
-.title = "Samples",
+.title = "Esempi",
 .author = "",
 .date = @date("2024-08-07:00:00:00"),
 .layout = "page.shtml",
 .custom = {
-	"mobile_menu_title": "Samples",
+	"mobile_menu_title": "Esempi",
 	"toc": true,
 },
 ---
 
-# [Calling external library functions]($heading.id('ext'))
-All system API functions can be invoked this way, you do not need library bindings to interface them.
+# [Chiamare funzioni da librerie esterne]($heading.id('ext'))
+Tutte le funzioni delle API di sistema possono essere invocate in questo modo, non sono necessari binding per interfacciarsi ad esse.
 
 []($code.language('=html').buildAsset("samples/0-windows-msgbox.zig"))
 
-# [Memory leak detection]($heading.id('leak'))
-Using `std.heap.GeneralPurposeAllocator` you can track double frees and memory leaks.
+
+# [Rilevamento di memory leak]($heading.id('leak'))
+Usando `std.heap.GeneralPurposeAllocator` puoi tracciare i double free e i memory leak.
 
 []($code.language('=html').buildAsset("samples/1-memory-leak.zig"))
 
 
-# [C interoperability]($heading.id('c-interop'))
-Example of importing a C header file and linking to both libc and raylib.
+# [Interoperabilità con C]($heading.id('c-interop'))
+Questo esempio importa un file di intestazione C e fa il link di `libc` e `raylib`.
 
 []($code.language('=html').buildAsset("samples/2-c-interop.zig"))
 
 
 # [Zigg Zagg]($heading.id('zigg-zagg'))
-Zig is *optimized* for coding interviews (not really).
+Zig è *ottimizzato* per i colloqui tecnici (non proprio).
 
 []($code.language('=html').buildAsset("samples/3-ziggzagg.zig"))
 
 
-# [Generic Types]($heading.id('generic'))
-In Zig types are comptime values and we use functions that return a type to implement generic algorithms and data structures. In this example we implement a simple generic queue and test its behaviour.
+# [Tipi generici]($heading.id('generic'))
+In Zig i tipi di dato sono valori conosciuti in fase di compilazione, e utilizziamo funzioni che restituiscono tipi per implementare algoritmi generici e strutture dati. In questo esempio implementiamo una semplice coda generica e testiamo il suo funzionamento.
 
 []($code.language('=html').buildAsset("samples/4-generic-type.zig"))
 
 
-# [Using cURL from Zig]($heading.id('curl'))
+# [Usare cURL da Zig]($heading.id('curl'))
 
 []($code.language('=html').buildAsset("samples/5-curl.zig"))

--- a/content/it-IT/learn/tools.smd
+++ b/content/it-IT/learn/tools.smd
@@ -1,21 +1,21 @@
 ---
-.title = "Tools",
+.title = "Strumenti",
 .author = "",
 .date = @date("2024-08-07:00:00:00"),
 .layout = "page.shtml",
 .custom = {
-	"mobile_menu_title": "Tools",
+	"mobile_menu_title": "Strumenti",
 	"toc": true,
 },
 ---
 
-# [Language Servers]($heading.id('lsp'))
-Language servers are editor-agnostic tools for obtaining syntax highlighting, autocompletion, and many other features. Consider using a Language server over a syntax-highlighting extension for a richer development experience.
+# [Server linguaggio]($heading.id('lsp'))
+I _server linguaggio_ sono strumenti generici (non legati ad uno specifico editor) che forniscono evidenziazione della sintassi, completamento automatico e molte altre funzioni. Per un'esperienza di sviluppo più agevole è consigliato l'utilizzo di un server linguaggio piuttosto che un'estensione di evidenziazione.
 
 - [zigtools/zls](https://github.com/zigtools/zls)
 
-# [Text Editors]($heading.id('editors'))
-Editor-specific tools, mostly syntax highlighters. 
+# [Editor di testo]($heading.id('editors'))
+Strumenti specifici per gli editor di testo, principalmente per evidenziare la sintassi.
 
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
@@ -32,7 +32,7 @@ Editor-specific tools, mostly syntax highlighters.
 ## Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-## JetBrains family ( IntelliJ IDEA, Fleet and etc)
+## Famiglia JetBrains (IntelliJ IDEA, Fleet e altri)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
 - [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)

--- a/content/it-IT/learn/tools.smd
+++ b/content/it-IT/learn/tools.smd
@@ -10,7 +10,7 @@
 ---
 
 # [Server linguaggio]($heading.id('lsp'))
-I _server linguaggio_ sono strumenti generici (non legati ad uno specifico editor) che forniscono evidenziazione della sintassi, completamento automatico e molte altre funzioni. Per un'esperienza di sviluppo più agevole è consigliato l'utilizzo di un server linguaggio piuttosto che un'estensione di evidenziazione.
+I *server linguaggio* sono strumenti generici (non legati ad uno specifico editor) che forniscono evidenziazione della sintassi, completamento automatico e molte altre funzioni. Per un'esperienza di sviluppo più agevole è consigliato l'utilizzo di un server linguaggio piuttosto che un'estensione di evidenziazione.
 
 - [zigtools/zls](https://github.com/zigtools/zls)
 

--- a/content/it-IT/learn/why_zig_rust_d_cpp.smd
+++ b/content/it-IT/learn/why_zig_rust_d_cpp.smd
@@ -1,16 +1,16 @@
 ---
-.title = "Why Zig When There is Already C++, D, and Rust?",
+.title = "Perchè Zig quando ci sono già C++, D e Rust?",
 .author = "",
 .date = @date("2024-08-07:00:00:00"),
 .layout = "page.shtml",
 .custom = {
-	"mobile_menu_title": "Why Zig?",
+	"mobile_menu_title": "Perchè Zig?",
 },
 ---
 
-# No hidden control flow
+# Nessun intervento nascosto sul flusso di esecuzione
 
-If Zig code doesn't look like it's jumping away to call a function, then it isn't. This means you can be sure that the following code calls only `foo()` and then `bar()`, and this is guaranteed without needing to know the types of anything:
+Se vedi del codice Zig e non sembra che stia chiamando una funzione, allora non lo sta facendo. Questo significa che il seguente codice chiamerà sicuramente solo `foo()` e poi `bar()`, e questo è garantito anche senza conoscere i tipi di dato utilizzati:
 
 ```zig
 var a = b + c.d;
@@ -18,141 +18,136 @@ foo();
 bar();
 ```
 
-Examples of hidden control flow:
+Esempi di controllo nascosto del flusso di esecuzione:
 
-* D has `@property` functions, which are methods that you call with what looks like field access, so in the above example, `c.d` might call a function.
-* C++, D, and Rust have operator overloading, so the `+` operator might call a function.
-* C++, D, and Go have throw/catch exceptions, so `foo()` might throw an exception, and prevent `bar()` from being called. (Of course, even in Zig `foo()` could deadlock and prevent `bar()` from being called, but that can happen in any Turing-complete language.)
+- D ha le funzioni `@property`, ovvero metodi che possono essere chiamati in un modo che sembra l'accesso a un attributo. Quindi, nell'esempio sopra, `c.d` potrebbe chiamare una funzione.
+- C++, D, e Rust supportano l'overload degli operatori, quindi l'operatore `+` potrebbe chiamare una funzione.
+- C++, D, e Go hanno eccezioni throw/catch, quindi `foo()` potrebbe lanciare un'eccezione, e impedire l'esecuzione di `bar()`. (Ovviamente, persino in Zig `foo()` potrebbe andare in stallo e impedire l'esecuzione di `bar()`, ma questo può avvenire in qualunque linguaggio Turing-completo.)
 
-The purpose of this design decision is to improve readability.
+Lo scopo di questa scelta progettuale è migliorare la leggibilità.
 
-# No hidden allocations
+# Nessuna allocazione dinamica nascosta
 
-Zig has a hands-off approach when it comes to heap allocation. There is no `new` keyword
-or any other language feature that uses a heap allocator (e.g. string concatenation operator[1]).
-The entire concept of the heap is managed by library and application code, not by the language.
+Zig ha un approccio schivo riguardo le allocazioni dinamiche. Non c'è alcuna parola chiave `new` o parte del linguaggio che fa uso di allocazioni dinamiche (per es. l'operatore di concatenazione di stringhe[1]).
+L'intero concetto di heap è gestito dal codice di librerie e applicazioni, non dal linguaggio.
 
-Examples of hidden allocations:
+Esempi di allocazioni dinamiche nascoste:
 
-* Go's `defer` allocates memory to a function-local stack. In addition to being an unintuitive
-  way for this control flow to work, it can cause out-of-memory failures if you use
-  `defer` inside a loop.
-* C++ coroutines allocate heap memory in order to call a coroutine.
-* In Go, a function call can cause heap allocation because goroutines allocate small stacks
-  that get resized when the call stack gets deep enough.
-* The main Rust standard library APIs panic on out of memory conditions, and the alternate
-  APIs that accept allocator parameters are an afterthought
-  (see [rust-lang/rust#29802](https://github.com/rust-lang/rust/issues/29802)).
+* Il `defer` in Go alloca in uno stack locale alla funzione. Oltre che essere una gestione poco intuitivo di questo flusso di esecuzione, può anche causare errori di riempimento della memoria se usi `defer` dentro un ciclo.
+* Le coroutine in C++ allocano memoria nello heap per chiamare una coroutine.
+* In Go, una chiamata a funzione può causare un'allocazione nello heap perchè le goroutine allocano piccoli stack che vengono ridimensionati quando lo stack di chiamate supera una certa soglia
+* Le API della principale libreria standard di Rust risultano in un kernel panic quando la memoria è piena, e le
+  API alternative che accettano come parametro un allocatore sono state una correzione fatta a posteriori
+  (vedi [rust-lang/rust#29802](https://github.com/rust-lang/rust/issues/29802)).
 
-Nearly all garbage collected languages have hidden allocations strewn about, since the
-garbage collector hides the evidence on the cleanup side.
+Quasi tutti i linguaggi garbage-collected hanno allocazioni dinamiche nascoste qua e là,
+dato che il garbage collector nasconde le prove con la fase di liberazione della memoria.
 
-The main problem with hidden allocations is that it prevents the *reusability* of a
-piece of code, unnecessarily limiting the number of environments that code would be
-appropriate to be deployed to. Simply put, there are use cases where one must be able
-to rely on control flow and function calls not to have the side-effect of memory allocation,
-therefore a programming language can only serve these use cases if it can realistically
-provide this guarantee.
+Il problema principale delle allocazioni dinamiche nascoste è che impediscono la *riusabilità*
+di un insieme di codice, limitando senza alcuna ragione il numero di ambienti appropriati
+che possono fare uso di quel codice. In sostanza, ci sono casi d'uso in cui è indispensabile
+poter essere sicuri che il flusso di esecuzione e le chiamate di funzioni non abbiano
+gli effetti collaterali delle allocazioni dinamiche, quindi un linguaggio di programmazione
+può essere adatto a questi casi d'uso solo se può dare questa garanzia.
 
-In Zig, there are standard library features that provide and work with heap allocators,
-but those are optional standard library features, not built into the language itself.
-If you never initialize a heap allocator, you can be confident your program will not heap allocate.
+In Zig, alcune parti della libreria standard forniscono e interagiscono con gli allocatori dinamici,
+ma sono Caratteristiche opzionali della libreria standard, non sono parte del linguaggio.
+Se non inizializzi alcun allocatore dinamico, hai la certezza che il tuo programma non allocherà nello heap.
 
-Every standard library feature that needs to allocate heap memory accepts an `Allocator` parameter
-in order to do it. This means that the Zig standard library supports freestanding targets. For
-example `std.ArrayList` and `std.AutoHashMap` can be used for bare metal programming!
+Ogni funzione della libreria standard che richiede allocazioni dinamiche accetta un parametro di tipo `Allocator`
+per poterlo fare. Questo significa che Zig supporta le piattaforme puramente hardware.
+Per esempio puoi usare `std.ArrayList` e `std.AutoHashMap` in sistemi embedded!
 
-Custom allocators make manual memory management a breeze. Zig has a debug allocator that
-maintains memory safety in the face of use-after-free and double-free. It automatically
-detects and prints stack traces of memory leaks. There is an arena allocator so that you can
-bundle any number of allocations into one and free them all at once rather than manage
-each allocation independently. Special-purpose allocators can be used to improve performance
-or memory usage for any particular application's needs.
+Gli allocatori personalizzati rendono la gestione della memoria una passeggiata. Zig ha un allocatore di debug
+che gestisce la sicurezza della memoria in caso di use-after-free e double-free.
+Automaticamente, rileva i memory leak e ne fornisce lo stack trace. C'è un allocatore ad area
+che permette di combinare un qualunque numero di allocazioni in una sola, per poi liberare
+l'area di memoria tutta insieme, invece di gestire singolarmente ogni allocazione.
+Allocatori a uso specifico possono essere utilizzati per migliorare le prestazioni
+o l'utilizzo di memoria, per soddisfare i requisiti di qualunque applicazione.
 
-[1]: Actually there is a string concatenation operator (generally an array concatenation operator), but it only works at compile time, so it still doesn't do any runtime heap allocation.
+[1]: In effetti c'è un operatore di concatenazione di stringhe (o meglio, concatenazione di array), ma funziona solo in fase di compilazione, quindi in ogni caso non esegue alcuna allocazione dinamica a runtime.
 
-# First-class support for no standard library
+# Nessun trattamento speciale per le librerie standard
 
-As hinted above, Zig has an entirely optional standard library. Each std lib API only gets compiled
-into your program if you use it. Zig has equal support for either linking against libc or
-not linking against it. Zig is friendly to bare-metal and high-performance development.
+Come suggerito nei paragrafi precedenti, Zig ha una libreria standard completamente opzionale.
+Ogni API della libreria standard viene compilata nel tuo programma solo se la usi.
+Che si decida o meno di linkare a `libc`, Zig offre lo stesso tipo di supporto.
+Zig aiuta lo sviluppo per sistemi hardware/embedded e applicazioni ad alte prestazioni.
 
-It's the best of both worlds; for example in Zig, WebAssembly programs can both use
-the normal features of the standard library, and still result in the tiniest binaries when
-compared to other programming languages that support compiling to WebAssembly.
+Così si prendono due piccioni con una fava; per esempio in Zig, i programmi WebAssembly
+possono usare le funzioni comuni della libreria standard, e comunque risultare in binari minuscoli
+in confronto ad altri linguaggi che supportano la compilazione per WebAssembly.
 
-# A Portable Language for Libraries
+# Un linguaggio portabile per le librerie
 
-One of the holy grails of programming is code reuse. Sadly, in practice, we find ourselves re-inventing the wheel many times over again. Often it's justified.
+Una dei pilastri della programmazione è il riuso del codice. Purtroppo, nella pratica, si finisce col dover reinventare la ruota più e più volte. Spesso questo sforzo è giustificato.
 
- * If an application has real-time requirements, then any library that uses garbage collection or any other non-deterministic behavior is disqualified as a dependency.
- * If a language makes it too easy to ignore errors, and thus hard to verify that a library correctly handles and bubbles up errors, it can be tempting to ignore the library and re-implement it, knowing that one handled all the relevant errors correctly. Zig is designed such that the laziest thing a programmer can do is handle errors correctly, and thus one can be reasonably confident that a library will properly bubble errors up.
- * Currently it is pragmatically true that C is the most versatile and portable language. Any language that does not have the ability to interact with C code risks obscurity. Zig is attempting to become the new portable language for libraries by simultaneously making it straightforward to conform to the C ABI for external functions, and introducing safety and language design that prevents common bugs within the implementations.
+ * Se un'applicazione ha requisiti real-time, allora ogni libreria che include garbage-collection o qualunque altro comportamento non deterministico non è accettabile come dipendenza.
+ * Se un linguaggio rende troppo semplice ignorare gli errori, e dunque rende difficile verificare che una libreria gestisca e comunichi correttamente gli errori, è naturale farsi tentare dall'idea di ignorare la libreria e re-implementarla, per avere la certezza di aver gestito correttamente tutti gli errori rilevanti. Zig è progettato in modo che la cose più pigra che un programmatore possa fare sia gestire gli errori correttamente, in modo che gli utenti della libreria possano essere ragionevolmente sicuri che gli errori siano comunicati (bubbling) correttamente.
+ * Al giorno d'oggi è pragmaticamente corretto affermare che C è il linguaggio più versatile e portabile. Ogni linguaggio che non permette di interfacciarsi a C rischia il decadimento. Zig sta tentando di diventare il nuovo linguaggio portabile per le librerie, rendendo semplice conformarsi all'ABI di C per le funzioni esterne, e allo stesso tempo introducendo scelte di progettazione e misure di sicurezza che prevengano comuni bug nella stessa implementazione.
 
-# A Package Manager and Build System for Existing Projects
+# Un gestore di pacchetti e sistema di build per progetti esistenti
 
-Zig is a toolchain in addition to a programming language. It comes with a
-[build system and package manager](/learn/build-system/) that are useful even
-in the context of a traditional C/C++ project.
+Zig è una toolchain, un insieme di strumenti, oltre a essere un linguaggio di programmazione.
+Include un [sistema di build e gestione di pacchetti](/learn/build-system/) che sono utili
+persino nel contesto di un progetto C/C++ tradizionale.
 
-Not only can you write Zig code instead of C or C++ code, but you can use Zig
-as a replacement for autotools, cmake, make, scons, ninja, etc. And on top of
-this, it provides a package manager for native dependencies. This build system
-is appropriate even if the entirety of a project's codebase is in C or C++.
-For example, by
-[porting ffmpeg to the zig build system](https://github.com/andrewrk/ffmpeg),
-it becomes possible to compile ffmpeg on any supported system for any supported
-system using only a [50 MiB download of zig](/download/). For open source
-projects, this streamlined ability to build from source - and even
-cross-compile - can be the difference between gaining or losing valuable
-contributors.
+Non solo puoi scrivere codice Zig invece di C o C++, ma puoi usare Zig
+come sostituto di autotools, cmake, make, scons, ninja, eccetera. In più,
+hai a disposizione un gestore di pacchetti per le dipendenze native. Questo build system
+è adatto persino a progetti scritti interamente in C or C++. Per esempio,
+[sostituendo il build system di ffmpeg con quello di Zig](https://github.com/andrewrk/ffmpeg),
+diventa possibile compilare ffmpeg *su* ogni piattaforma supportata *per* ogni piattaforma supportata,
+usando solo un [download di Zig da 50 Mib](/download/). Per i progetti open source,
+questa semplificazione della compilazione da codice sorgente - e cross-compilazione - può fare
+la differenza tra l'attirare o il perdere preziosi contributori.
 
-System package managers such as apt-get, pacman, homebrew, and others are
-instrumental for end user experience, but they can be insufficient for the
-needs of developers. A language-specific package manager can be the difference
-between having no contributors and having many. For open source projects, the
-difficulty of getting the project to build at all is a huge hurdle for
-potential contributors. For C/C++ projects, having dependencies can be fatal,
-especially on Windows, where there is no package manager. Even when just
-building Zig itself, most potential contributors have a difficult time with the
-LLVM dependency. Zig offers a way for projects to depend on native libraries
-directly - without depending on the users' system package manager to have the
-correct version available, and in a way that is practically guaranteed to
-successfully build projects on the first try regardless of what system is being
-used and independent of what platform is being targeted.
+I gestori di pacchetti di sistema come apt-get, pacman, homebrew e altri sono fondamentali
+per l'user-experience degli utenti finali, ma possono essere insufficienti per le necessità
+degli sviluppatori. Un gestore di pacchetti specifico per un linguaggio può fare la differenza
+tra il non avere contributori e averne molti. Per i progetti open source, la difficoltà di
+riuscire anche solo a compilare il progetto è un grande ostacolo per i potenziali contributori.
+Per i progetti C/C++, avere dipendenze può essere fatale, specialmente su Windows,
+che non ha un suo gestore di pacchetti. Persino con la compilazione dello stesso Zig da sorgente,
+la maggior parte dei nostri potenziali contributori hanno difficoltà con la dipendenza da LLVM.
+Zig offre ai progetti un modo per dipendere direttamente dalle librerie native, ma senza che gli utenti
+debbano per forza avere la versione corretta disponibile nel loro gestore di pacchetti, e in un modo che
+compila praticamente sempre al primo tentativo a prescindere dalla piattaforma *su* cui si sta compilando,
+o *per* cui si sta compilando.
 
-**Other languages have package managers but they do not eliminate pesky system
-dependencies like Zig does.**
+**Altri linguaggi includono un gestore di pacchetti, ma non eliminano
+la necessità delle dipendenze di sistema come fa Zig.**
 
-Zig can replace a project's build system with a reasonable language using
-a declarative API for building projects, that also provides package management,
-and thus the ability to actually depend on other C libraries. The ability to
-have dependencies enables higher level abstractions, and thus the proliferation
-of reusable high-level code.
+Zig può sostituire il build system di un progetto con un linguaggio ragionevole
+che fornisce un'API dichiarativa per compilare i progetti, e che si occupa anche della gestione dei pacchetti,
+rendendo quindi possibile dipendere davvero da altre librerie C
+La possibilità di avere dipendenze apre la strada a livelli di astrazione più alti,
+e quindi alla proliferazione di codice ad alto livello riutilizzabile.
 
-# Simplicity
+# Semplicità
 
-C++, Rust, and D have such a large number of features that they can be distracting from the actual meaning of the application you are working on. One finds oneself debugging one's knowledge of the programming language instead of debugging the application itself.
+C++, Rust e D hanno così tante funzioni disponibili che possono finire col distrarre dall'effettivo significato del codice che si sta scrivendo. Così ci si ritrova a debuggare la propria conoscenza del linguaggio di programmazione, invece di debuggare il programma.
 
-Zig has no macros yet is still powerful enough to express complex programs in a
-clear, non-repetitive way. Even Rust has macros with special cases like
-`format!`, which is implemented in the compiler itself. Meanwhile in Zig, the
-equivalent function is implemented in the standard library with no special case
-code in the compiler.
+Zig non ha macro, eppure è abbastanza potente da esprimere programmi complessi
+in modo chiaro e senza ripetizioni. Persino Rust ha delle macro "speciali" come
+`format!`, che è implementata direttamente nel compilatore.
+Invece in Zig la funzione equivalente è implementata nella libreria standard,
+senza il bisogno di aggiungere controlli specifici nel compilatore.
 
-# Tooling
+# Strumenti
 
-Zig can be downloaded from [the downloads section](/download/).  Zig provides
-binary archives for Linux, Windows, and macOS. The following describes what you
-get with one of these archives:
+Zig può essere scaricato dalla [sezione download](/download/).
+Sono disponibili archivi compressi per Linux, Windows e macOS.
+La seguente lista indica cosa ottieni con uno di questi archivi:
 
-* installed by downloading and extracting a single archive, no system configuration needed
-* statically compiled so there are no runtime dependencies
-* supports using LLVM for optimized release builds while using Zig's custom backends for faster compilation performance
-* additionally supports a backend for outputting C code
-* out of the box cross-compilation to most major platforms
-* ships with source code for libc that will be dynamically compiled when needed for any supported platform
-* includes build system with concurrency and caching
-* compiles C and C++ code with libc support
-* drop-in GCC/Clang command line compatibility with `zig cc`
-* Windows resource compiler
+* installazione scaricando ed estraendo un archivio, nessuna configurazione di sistema richiesta
+* compilato staticamente quindi non c'è nessuna dipendenza a runtime
+* supporto a LLVM per build ottimizzate, e backend integrati in Zig per ridurre i tempi di compilazione
+* un backend per produrre codice C invece di un file binario
+* cross-compilazione subito disponibile per la maggior parte delle piattaforme più comuni
+* codice sorgente di `libc` che verrà compilato dinamicamente quando necessario per qualunque piattaforma
+* un build system con processi concorrenti e caching
+* compilazione di codice C e C++ con supporto a `libc`
+* compatibilità con le opzioni da riga di comando di GCC/Clang usando `zig cc`
+* compilatore di risorse Windows

--- a/content/it-IT/zsf.smd
+++ b/content/it-IT/zsf.smd
@@ -7,9 +7,9 @@
 	"mobile_menu_title": "ZSF",
 },
 ---
-# Sponsoring the Zig Software Foundation
+# Sostenere la Zig Software Foundation
 
-Donazioni ricorrenti sono apprezzate. Mantenere e supportare codice di alta qualita' richiede lavoro continuativo!
+Il modo migliore per sostenerci sono le donazioni ricorrenti. Mantenere e supportare software di alta qualità richiede lavoro continuo!
 
 ```=html
 <div id="zsf-every-donate-btn">
@@ -46,53 +46,46 @@ Donazioni ricorrenti sono apprezzate. Mantenere e supportare codice di alta qual
 
 
 ## La missione
-La missione della Zig Software Foundation e' di promuovere, progettere, e far progredire il linguaggio di programmazione Zig, di supportare e facilitare la crescita di una comunita' diversa e internazionale di programmatori Zig, e di offrire formazione e direzione ad eventuali studenti, al fine di insegnare ad una nuova generazione di programmatori ad essere competenti, etici, e a ritenersi reciprocamente a standar elevati.
+La missione della Zig Software Foundation è di promuovere, proteggere e far progredire il linguaggio di programmazione Zig; di supportare e facilitare la crescita di una comunità variegata e internazionale di programmatori Zig; di offrire formazione e direzione ad eventuali studenti, al fine di insegnare alla nuova generazione di programmatori ad essere competenti, etici, e a spronarsi reciprocamente a tenere degli standard alti.
 
+**ZSF è un'associazione non-profit statunitense 501(c)(3).** Rendiconto finanziario, verbali delle riunioni e ulteriopri dettagli sono [pubblici e disponibili](https://drive.google.com/drive/folders/1ucHARxVbhrBbuZDbhrGHYDTsYAs8_bMH?usp=sharing).
 
-**ZSF e' una associazione Americana non-profit 501(c)(3).** Situazione finanziara, verbali delle riunioni, e ulteriopri dettagli sono [disponibili al pubblico](https://drive.google.com/drive/folders/1ucHARxVbhrBbuZDbhrGHYDTsYAs8_bMH?usp=sharing). 
-
-## La board amministrativa
+## Membri del consiglio direttivo
 
 - [Andrew Kelley](https://andrewkelley.me/) (Presidente)
 - [Josh Wolfe](https://github.com/thejoshwolfe/) (Segretario)
 - [Mason Remaley](https://www.masonremaley.com/) (Tesoriere)
 
-# Sponsorship
+# Diventare sponsor
 
-## Supportare la Fondazione
+Donando alla ZSF, puoi finanziare lo sviluppo del linguaggio di programmazione Zig e il suo ecosistema, che a sua volta porta benefici al resto della comunità open-source. Membri della comunità di Zig hanno scoperto e corretto bug in [LLVM](https://llvm.org/), [Wine](https://winehq.org/), [QEMU](https://qemu.org/), [musl libc](https://musl.libc.org/), [GDB](https://www.gnu.org/software/gdb/) e altri progetti.
 
-Donando alla ZSF, puoi supportare lo sviluppo del linguaggio di programmazione Zig e il suo ecosistema, che a sua volta porta benefici alla generale comunita' open-source. Membri della comunita' Zig hanno corretto bug in [LLVM](https://llvm.org/), [Wine](https://winehq.org/), [QEMU](https://qemu.org/), [musl libc](https://musl.libc.org/), [GDB](https://www.gnu.org/software/gdb/) e altri progetti.
+La Zig Software Foundation è una piccola associazione che fa un uso efficiente delle proprie risorse monetarie. Il piano è di rimanere piccoli ed agili, ma abbiamo comunque intenzione di convertire i nostri volontari in collaboratori stipendiati per aiutare a gestire il progetto e velocizzare i progressi verso la versione 1.0. La ZSF è una non-profit proprio per valorizzare le persone. Stiamo cercando di fare in modo che i volontari dell'open source vengano pagati per il proprio tempo.
 
-La Zig Software Foundation e' una piccola organizzation che fa uso efficiente delle proprie risorse monetarie. Il piano e' di rimanere piccoli ed agili, ma abbiamo comunque intenzione di convertire i nostri volontari in maintainer stipendiati per aiutare a fare merge di pull request e per velocizzare il progresso verso una versione 1.0. ZSF e' una non-profit per assicurarsi di potare benefici alle persone coinvolte nel progetto e per questo vogliamo fare in modo che i maintaner open-source vengano pagati per il proprio tempo.
-
-Per donazioni singole e altre domande, perfavore conttatateci all'indirizzo: donations@ziglang.org.
-Email in italiano vanno bene.
-
-## Informazioni per donazioni
-Ecco alcune informazioni utili a donare tramite metodi diversi da GitHub Sponsors.
+# Come donare
+Ecco alcune informazioni utili a donare.
 
 ## EIN
 84-5105214
 
-## Address
-Zig Software Foundation  
-1632 1st Ave #21385  
+## Indirizzo
+Zig Software Foundation
+1632 1st Ave #21385
 New York, NY 10028
 
-### Tramite di donazione supportati
+### Alcuni metodi di donazione supportati
 - [Every](https://www.every.org/zig-software-foundation-inc/) (supporta criptovalute!)
 - [GitHub Sponsors](https://github.com/sponsors/ziglang)
 - [Benevity](https://benevity.com)
-- Trasferimento bancario (disponibile da ogni paese che supporta SWIFT, contattateci per ulteriori informazioni)
+- Trasferimento bancario (disponibile da ogni istituto che supporta SWIFT, contattateci per ulteriori informazioni)
 - Invio di assegni cartacei per posta (metodo supportato solo negli Stati Uniti)
 - [Wise](https://wise.com)
 
-
-**Perfavore non esistate a contattarci a donations@ziglang.org se avete domande o esigenze particolari.**
+**Se hai delle domande o esigenze particolari, non esitare a contattarci all'indirizzo donations@ziglang.org, puoi scriverci in italiano.**
 
 # Aziende sponsor
 
 ### Donazioni monetarie
-Le seguenti compagnie offrono diretto supporto finanziario alla Zig Software Foundation donando piu' di 1000 USD al mese.
+Le seguenti compagnie offrono supporto finanziario diretto alla Zig Software Foundation donando più di 1000$ (USD) al mese.
 
 []($code.language('=html').siteAsset('corporate-sponsors.html'))

--- a/content/it-IT/zsf.smd
+++ b/content/it-IT/zsf.smd
@@ -69,8 +69,8 @@ Ecco alcune informazioni utili a donare.
 84-5105214
 
 ## Indirizzo
-Zig Software Foundation
-1632 1st Ave #21385
+Zig Software Foundation  
+1632 1st Ave #21385  
 New York, NY 10028
 
 ### Alcuni metodi di donazione supportati

--- a/i18n/it-IT.ziggy
+++ b/i18n/it-IT.ziggy
@@ -6,7 +6,7 @@
 .latest_release = "Ultima Release:",
 .documentation = "Documentazione",
 .changes = "Changelog",
-.overview = "Overview dettagliata",
+.overview = "Panoramica dettagliata",
 .code_samples = "Altri esempi di codice",
 .all_communities = "Esplora le comunità",
 .learn_more = "Ulteriori dettagli",
@@ -19,7 +19,7 @@
 .download_os = "OS",
 .download_arch = "Architettura",
 .download_filename = "Nome del file",
-.download_sig = "Firma Crittografica",
+.download_sig = "Firma crittografica",
 .download_size = "Dimensione",
 // base.shtml
-.footer = "Questa pagina e' disponibile anche nei seguenti linguaggi",
+.footer = "Questa pagina è disponibile anche nei seguenti linguaggi",


### PR DESCRIPTION
Improves existing translations, and translates all missing content.

I used mostly the Italian Wikipedia and university slides to decide how to translate some concepts, I also checked most things with a grammar tool so I think this should be a pretty good quality translation overall.

I left a couple paragraphs untranslated, because the are very outdated (e.g async and "there's no package manager yet") and I'm pretty sure they will be removed entirely.