### PR TITLE
css: sync some syntax highlight colors with language reference

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -364,7 +364,7 @@ h4:lang(ja) {
   pre>code,
   samp {
     background: #1e1e1e;
-    color: #f8f8f2;
+    color: #ccc;
     line-height: normal;
   }
 
@@ -390,7 +390,7 @@ h4:lang(ja) {
   }
 
   .tok-fn {
-    color: #e33;
+    color: #B1A0F8;
   }
 
   .tok-null {


### PR DESCRIPTION
The "new" colors come from the language reference and make it easier to read function names and to differentiate keywords from the rest of the code.

Here's an example with the second code block in [this page](https://ziglang.org/learn/build-system/):

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ae0c1396-ab32-46ec-826b-51cf6b094fba) | ![image](https://github.com/user-attachments/assets/ad1c0214-9840-4252-b4aa-040b525c113f) |

I think keywords should have a different color especially in the light theme, and operators need their own token class, but that's for another PR if syntax highlighting is something you are open to improve.