### PR TITLE
css: fix blockquotes and box element

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -108,7 +108,7 @@ th,
   border-bottom: 2px solid grey;
 }
 
-tr:nth-child(even)>td {
+tr:nth-child(even) > td {
   background: #f2f3f3;
 }
 
@@ -121,7 +121,6 @@ tr:nth-child(even)>td {
 
 
 /* Captions for code blocks */
-
 
 .file {
   font-weight: bold;
@@ -156,7 +155,7 @@ code {
   direction: ltr;
 }
 
-pre>code,
+pre > code,
 samp {
   display: block;
   overflow: auto;
@@ -259,6 +258,9 @@ blockquote {
   padding: 0.8em 1em;
 }
 
+
+/* Terminal code coloring */
+
 .sgr-1m {
   font-weight: bold;
 }
@@ -333,11 +335,11 @@ blockquote {
     border-color: grey;
   }
 
-  tr:nth-child(even)>td {
+  tr:nth-child(even) > td {
     background: #1e1e1e;
   }
 
-  pre>code,
+  pre > code,
   samp {
     background: #1e1e1e;
     color: #ccc;
@@ -409,6 +411,8 @@ blockquote {
     background-image: url(/zig-logo-light.svg);
     margin: 10px 0;
   }
+
+  /* Terminal code coloring */
 
   .sgr-2m {
     color: grey;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -255,6 +255,14 @@ h4:lang(ja) {
   padding: 0 1em;
 }
 
+blockquote {
+  margin-left: 0;
+  margin-right: 0;
+  padding: 0 1em;
+  border-left: .25em solid #d1d7db;
+  color: #59626b;
+}
+
 .sgr-1m {
   font-weight: bold;
 }
@@ -299,6 +307,11 @@ h4:lang(ja) {
   body {
     background-color: #111;
     color: #bbb;
+  }
+
+  blockquote {
+    border-left: .25em solid #666;
+    color: #949494;
   }
 
   .box {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -120,30 +120,6 @@ tr:nth-child(even)>td {
 }
 
 
-
-.t0_1,
-.t37,
-.t37_1 {
-  font-weight: bold;
-}
-
-.t2_0 {
-  color: grey;
-}
-
-.t31_1 {
-  color: red;
-}
-
-.t32_1 {
-  color: green;
-}
-
-.t36_1 {
-  color: #0086b3;
-}
-
-
 /* Captions for code blocks */
 
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -245,22 +245,18 @@ h4:lang(ja) {
   font-feature-settings: 'palt';
 }
 
-.box {
-  border: 1px solid black;
-  border-radius: 5px;
-  padding: 1em;
-}
-
-.box.thin {
-  padding: 0 1em;
-}
-
 blockquote {
   margin-left: 0;
   margin-right: 0;
   padding: 0 1em;
   border-left: .25em solid #d1d7db;
   color: #59626b;
+}
+
+.box {
+  border: 1px solid #666;
+  border-radius: 5px;
+  padding: 0.8em 1em;
 }
 
 .sgr-1m {
@@ -315,7 +311,7 @@ blockquote {
   }
 
   .box {
-    border-color: white;
+    border-color: #bbb;
   }
 
   a {

--- a/content/en-US/news/statement-regarding-zen-programming-language.smd
+++ b/content/en-US/news/statement-regarding-zen-programming-language.smd
@@ -11,7 +11,8 @@
 	"lang": "ja",
 }
 ---
->Original English version available below. We are thankful to <a href="https://hyperia.co.jp/" target="_blank" rel="noopener noreferrer">株式会社HYPERIA</a> and all the members of the Zig community that helped us with the Japanese translation. 
+
+Original English version available below. We are thankful to <a href="https://hyperia.co.jp/" target="_blank" rel="noopener noreferrer">株式会社HYPERIA</a> and all the members of the Zig community that helped us with the Japanese translation.
 
 # Zigソフトウェア財団とZenプログラミング言語に関する声明
 
@@ -29,11 +30,7 @@ Zenが独立的に進化してきたという主張については、私ども�
 
 以下内容は私どもの公式ウェブサイトからの引用で、Zigソフトウェア財団の使命です。
 
-{{< box >}} 
-<i>
-Zigソフトウェア財団の使命は、Zigプログラミング言語を促進・保護・発展させること、Zigプログラマーの多様で国際的なコミュニティの成長を支えること、また学生に教育と指導を提供し、次世代のプログラマーを有能かつ倫理的に高い水準を持つ人材へと育成することです。
-</i>
-{{< /box >}}
+> Zigソフトウェア財団の使命は、Zigプログラミング言語を促進・保護・発展させること、Zigプログラマーの多様で国際的なコミュニティの成長を支えること、また学生に教育と指導を提供し、次世代のプログラマーを有能かつ倫理的に高い水準を持つ人材へと育成することです。
 
 コネクトフリー社の創設者であるテイト氏は、[不完全な技術論](https://github.com/ziglang/zig/issues/1530)により彼自身の行動を正当化しようとすると同時に、契約条項を利用してZigの貢献者がこのオープンソースプロジェクトに更に貢献する事を阻止しています。また、コネクトフリー社のZenはZigを表面的にリブランディングしたものに過ぎません。このようなテイト氏の過去と現在の振舞いから、日本の専門家や会社がこうしたクローズドソース製品に頼り生計をたてようとするのは、私どもの良識としてはお勧めできません。
 
@@ -80,11 +77,7 @@ As for the development team, connectFree omits how “No. 5” (i.e. Kristopher 
 
 Taken from our official website, this is the mission of the Zig Software Foundation:
 
-{{< box >}} 
-<i>
-The mission of the Zig Software Foundation is to promote, protect, and advance the Zig programming language, to support and facilitate the growth of a diverse and international community of Zig programmers, and to provide education and guidance to students, teaching the next generation of programmers to be competent, ethical, and to hold each other to high standards.
-</i>
-{{< /box >}}
+> The mission of the Zig Software Foundation is to promote, protect, and advance the Zig programming language, to support and facilitate the growth of a diverse and international community of Zig programmers, and to provide education and guidance to students, teaching the next generation of programmers to be competent, ethical, and to hold each other to high standards.
 
 
 Given past and present behavior by Mr. Tate, we can’t in good conscience recommend to Japanese professionals and businesses to make their livelihood depend on a closed-source, superficial rebranding of Zig, sold by a company whose founder uses [flawed technical arguments](https://github.com/ziglang/zig/issues/1530) to justify his actions while leveraging contractual clauses to prevent Zig contributors from further contributing to the open-source project.

--- a/content/en-US/news/statement-regarding-zen-programming-language.smd
+++ b/content/en-US/news/statement-regarding-zen-programming-language.smd
@@ -12,7 +12,11 @@
 }
 ---
 
-Original English version available below. We are thankful to <a href="https://hyperia.co.jp/" target="_blank" rel="noopener noreferrer">株式会社HYPERIA</a> and all the members of the Zig community that helped us with the Japanese translation.
+```=html
+<p class="box">
+    Original English version available below. We are thankful to <a href="https://hyperia.co.jp/" target="_blank" rel="noopener noreferrer">株式会社HYPERIA</a> and all the members of the Zig community that helped us with the Japanese translation.
+</p>
+```
 
 # Zigソフトウェア財団とZenプログラミング言語に関する声明
 
@@ -57,8 +61,8 @@ Zig Software Foundation
 
 ```=html
 <div style="width: 100%; text-align: center; margin-top: 2em; margin-bottom: 1em;">
-      <span><i>Original English version follows.</i></span>
-    </div>
+    <span><i>Original English version follows.</i></span>
+</div>
 ```
 
 # Statement Regarding the Zen Programming Language


### PR DESCRIPTION
Currently two pages use blockquotes:
- https://ziglang.org/news/jakub-konka-hired-full-time/
- https://ziglang.org/news/statement-regarding-zen-programming-language/

This PR adds styling for these otherwise unstyled elements. It also replaces two stray `{{< Box >}}` with this styling, since they are quotes from another page.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/e44f4cf0-b88d-4de5-91ab-d16769453495) | ![image](https://github.com/user-attachments/assets/6f00e0b2-9b18-4f12-9f8f-aed8253b10ae) |
| ![image](https://github.com/user-attachments/assets/9bc80416-d654-4b9a-82de-58165f9cb2ac) | ![image](https://github.com/user-attachments/assets/a23d9158-9c16-4142-a2a9-3210540c6799) |
| ![image](https://github.com/user-attachments/assets/1e607035-fc50-4b58-a11e-43690f6984c9) | ![image](https://github.com/user-attachments/assets/3113042e-e661-435c-96f7-3471018b4bac) |

---
 
This PR also reapplies the "box" class that was used [before](https://web.archive.org/web/20240122125641/https://ziglang.org/news/statement-regarding-zen-programming-language/) the transition to Zine:
| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/f150ada8-cfb3-4e7d-8eaa-fa197e8b89d4) | ![image](https://github.com/user-attachments/assets/6eb013a4-3c88-47a1-86af-b6ab9bfd69a8) |

Note that this is the only time the `box` class is used in the whole website. I kept it since the CSS was already there and the page looked like that before the transition from Hugo to Zine.

---

This PR also removes unused classes that I re-added by mistake in https://github.com/ziglang/www.ziglang.org/pull/405