### PR TITLE
fix: show translation info in the footer all translated pages

### DIFF
--- a/layouts/index.shtml
+++ b/layouts/index.shtml
@@ -134,15 +134,4 @@
       <p :text="$i18n.get('github_sponsors_update_frequency')"></p>
     </div>
   </div>
-  <div
-    :if="$site.localeCode().eql('en-US').not()"
-    class="container"
-  >
-    <div style="display: flex; flex-direction: row; justify-content: space-around; margin-top: 20px;">
-      <span>This page was translated by the Zig community,
-        <a href="$page.locale('en-US').link()">see the original version</a>
-        or
-        <a href="https://github.com/ziglang/www.ziglang.org/" class="external-link" target="_blank" rel="noopener">report errors</a>.</span>
-    </div>
-  </div>
 </div>

--- a/layouts/templates/locale.shtml
+++ b/layouts/templates/locale.shtml
@@ -3,6 +3,15 @@
 <head id="head"><super></head>
 <div id="content" role="main"><super></div>
 <div id="languages-menu">
+  <ctx :if="$site.localeCode().eql('en-US').not()">
+    <div class="container">
+      <span>This page was translated by the Zig community,
+        <a href="$page.locale('en-US').link()">see the original version</a>
+        or
+        <a href="https://github.com/ziglang/www.ziglang.org/" class="external-link" target="_blank" rel="noopener">report errors</a>.</span>
+    </div>
+    <br>
+  </ctx>
   <span :text="$i18n.get('languages_menu')"></span>
   <br>
   <div :loop="$page.locales()">


### PR DESCRIPTION
Previously this message was shown only in the home page, now it's displayed in any translated page.

I removed the inline CSS (`display: flex; flex-direction: row; justify-content: space-around; margin-top: 20px;`) because I could not get the text justification to work and at the very least now the styling is consistent between this message and the languages menu text.

| Before | After |
|---|---|
|  ![image](https://github.com/user-attachments/assets/a3aa98b8-271a-4b3b-a6c3-cfc2e45cece1) | ![image](https://github.com/user-attachments/assets/6fda5588-bce4-400f-a8c5-be57de17ceea) |

To test, go to any translated page and if the language is not English you should see "This page was translated by the Zig community" above the language menu.

I am unsure how this message can be translated since it contains HTML tags.