### PR TITLE
css: improve code sample margins in homepage

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -78,8 +78,10 @@
 }
 
 .features h2 {
-
   font-size: 2.0em;
+}
+.features h2:first-of-type {
+  margin-top: 0;
 }
 
 .nav-spacer {
@@ -102,6 +104,7 @@
 
 .codesample {
   overflow-x: auto;
+  margin-top: 13px;
   margin-left: 20px;
 }
 
@@ -172,8 +175,7 @@
 
   .codesample {
     margin-left: 0;
-    /*width: 100%;*/
-    margin: auto;
+    margin-top: 20px;
   }
 
   .cta-buttons {

--- a/layouts/index.shtml
+++ b/layouts/index.shtml
@@ -47,7 +47,7 @@
       </div>
     </div>
   </div>
-  <div class="container" style="display:flex;flex-direction:row;flex-wrap:wrap;padding:20px 0;justify-content:space-between">
+  <div class="container" style="display:flex;flex-direction:row;flex-wrap:wrap;padding:30px 0 20px; justify-content:space-between;">
     <div class="features">
       <div :html="$page.contentSection('features')"></div>
       <div style="display:flex;flex-direction:row;flex-wrap:wrap;justify-content:center">


### PR DESCRIPTION
Differences on mobile, more separation between elements.
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/504d650a-c14d-4406-8f37-0d76b8f189f6) | ![image](https://github.com/user-attachments/assets/e930a2c0-50f9-415d-a220-df1d7c78f8c7) |

---

On desktop screens,  align elements on same row.

Before:
![image](https://github.com/user-attachments/assets/38601c11-12d7-4da3-a89b-f7e31f4018c4)

After:
![image](https://github.com/user-attachments/assets/9f757022-e3db-4e57-a583-5f868df95f6f)
