### PR TITLE
Add new learning resource to "Learn" page

### DIFF
--- a/content/de-DE/learn/index.smd
+++ b/content/de-DE/learn/index.smd
@@ -38,6 +38,8 @@ Wenn du bereit bist mit der Programmierung in Zig zu beginnen, hilft dir diese A
 - [Erste Schritte](./getting-started)  
 
 ## Online-Lernressourcen
+- [Introduction to Zig: a project-based book](https://github.com/pedropark99/zig-book)
+Ein offenes, technisches Einführungsbuch für Zig.
 - [zig.guide](https://zig.guide)  
 Eine strukturierte Einführung in Zig von [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://ziglings.org)  

--- a/content/en-US/learn/index.smd
+++ b/content/en-US/learn/index.smd
@@ -38,6 +38,8 @@ If you're ready to start programming in Zig, this guide will help you setup your
 - [Getting started](./getting-started)  
 
 ## Online learning resources
+- [Introduction to Zig: a project-based book](https://github.com/pedropark99/zig-book)
+An open, technical and introductory book for Zig.
 - [zig.guide](https://zig.guide)  
 A structured introduction to Zig by [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://ziglings.org)  

--- a/content/it-IT/learn/index.smd
+++ b/content/it-IT/learn/index.smd
@@ -35,6 +35,8 @@ Se hai deciso di iniziare a programmare in Zig, questa guida ti aiuterà ad otte
 - [Inizia qui](./getting-started)
 
 ## Materiale didattico online
+- [Introduction to Zig: a project-based book](https://github.com/pedropark99/zig-book)
+Un libro aperto, tecnico e introduttivo per Zig.
 - [zig.guide](https://zig.guide)
 Un'introduzione strutturata a Zig, creata da [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://ziglings.org)

--- a/content/ja-JP/learn/index.smd
+++ b/content/ja-JP/learn/index.smd
@@ -38,6 +38,8 @@ Zigでプログラミングを始める準備ができたら、このガイド�
 - [始めましょう](./getting-started)  
 
 ## オンライン学習リソース
+- [Introduction to Zig: a project-based book](https://github.com/pedropark99/zig-book)
+Zig のオープンな技術入門書。
 - [Zigを学ぶ](https://zig.guide) [Sobeston](https://github.com/sobeston)によるZigの構造的な紹介。
 - [Ziglings](https://ziglings.org)
 小さな壊れたプログラムを修正することでZigを学ぶ。

--- a/content/uk-UA/learn/index.smd
+++ b/content/uk-UA/learn/index.smd
@@ -38,6 +38,8 @@
 - [Початок Роботи](./getting-started)  
 
 ## Онлайн-ресурси навчання
+- [Introduction to Zig: a project-based book](https://github.com/pedropark99/zig-book)
+Відкрита технічна вступна книга для Zig.
 - [zig.guide](https://zig.guide)  
 Структурований вступ до Zig від [Sobeston](https://github.com/sobeston).
 - [Ziglings](https://ziglings.org)  

--- a/content/zh-CN/learn/index.smd
+++ b/content/zh-CN/learn/index.smd
@@ -36,6 +36,8 @@ Zig 构建系统的介绍。
 - [快速入门](./getting-started)
 
 ## 在线学习资源
+- [Introduction to Zig: a project-based book](https://github.com/pedropark99/zig-book)
+Zig 的一本開放式科技入門書。
 - [zig.guide](https://zig.guide)  
 Zig 的结构化介绍，由 [Sobeston](https://github.com/sobeston) 编写。
 - [Ziglings](https://ziglings.org)  


### PR DESCRIPTION
This PR adds a hyperlink to the project "Introduction to Zig: a project-based book" into the "Learn" page of the ziglang.org website.

You can know more about this project at: https://github.com/pedropark99/zig-book

If this PR have any problems in it, then let me know and I will fix it 😉
Thank you for your attention!