### PR TITLE
fix Golang does not have throw/catch

### DIFF
--- a/content/en-US/learn/overview.smd
+++ b/content/en-US/learn/overview.smd
@@ -26,7 +26,7 @@ Examples of hidden control flow:
 
 - D has `@property` functions, which are methods that you call with what looks like field access, so in the above example, `c.d` might call a function.
 - C++, D, and Rust have operator overloading, so the `+` operator might call a function.
-- C++, D, and Go have throw/catch exceptions, so `foo()` might throw an exception, and prevent `bar()` from being called.
+- C++ and D have throw/catch exceptions, so `foo()` might throw an exception, and prevent `bar()` from being called.
 
  Zig promotes code maintenance and readability by making all control flow managed exclusively with language keywords and function calls.
 


### PR DESCRIPTION
Hi!

This is a fix of a mistake in the [overview page](https://ziglang.org/learn/overview/).

> C++, D, and **Go have throw/catch** exceptions, so foo() might throw an exception, and prevent bar() from being called.

Golang does not have throw/catch syntax.  An error value in a multiple return is used instead.

Golang:
```Go
	message, err := greetings.Hello("")
	if err != nil {
		log.Fatal(err)
	}
```

- https://go.dev/doc/effective_go#errors
- https://go.dev/blog/error-handling-and-go
-  https://go.dev/doc/tutorial/handle-errors