### PR TITLE
clarification about Go panic/recover

### DIFF
--- a/content/en-US/learn/overview.smd
+++ b/content/en-US/learn/overview.smd
@@ -26,7 +26,7 @@ Examples of hidden control flow:
 
 - D has `@property` functions, which are methods that you call with what looks like field access, so in the above example, `c.d` might call a function.
 - C++, D, and Rust have operator overloading, so the `+` operator might call a function.
-- C++, D, and Go have throw/catch exceptions, so `foo()` might throw an exception, and prevent `bar()` from being called.
+- C++ and D have throw/catch exceptions, Go has panic/recover, so `foo()` might throw an exception, and prevent `bar()` from being called.
 
  Zig promotes code maintenance and readability by making all control flow managed exclusively with language keywords and function calls.
 


### PR DESCRIPTION
Hello @kristoff-it!

Indeed, Golang has throw/catch in a panic/recover form. Thank you for the [explanation blog post](https://kristoff.it/blog/go-exceptions/). But that line in the overview that adds throw/catch to the Golang makes Go developers feel really awkward. I do not think this is the best feeling for an overview page of a new language.

I think this form is more attractive, because it allows to look at Golang error handling from a new perspective. And also gives respect to the Zig authors, when the old one pushes into unpleasant emotions.

> C++ and D have throw/catch exceptions, Go has panic/recover, so `foo()` might throw an exception, and prevent `bar()` from being called.

Thank you.