### PR TITLE
Show --help in user-provided options example

### DIFF
--- a/assets/zig-code/build-system/2-user-provided-options/build.zig
+++ b/assets/zig-code/build-system/2-user-provided-options/build.zig
@@ -15,5 +15,4 @@ pub fn build(b: *std.Build) void {
 }
 
 // build=succeed
-// additional_option=--summary
-// additional_option=all
+// additional_option=--help


### PR DESCRIPTION
Based on the example's context and how it looke back in [feb 2024](https://web.archive.org/web/20240222135153/https://ziglang.org/learn/build-system/), I assume we should be displaying the `--help` in the "user-provided options" example.