### PR TITLE
Update getting-started.smd

### DIFF
--- a/content/en-US/learn/getting-started.smd
+++ b/content/en-US/learn/getting-started.smd
@@ -98,7 +98,7 @@ brew install zig
 
 **MacPorts**
 ```
-port install zig
+sudo port install zig
 ```
 ### Linux
 Zig is also present in many package managers for Linux. [Here](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)


### PR DESCRIPTION
macports asks for sudo. Otherwise it will not be executed: 
```bash
port install zig

Error: Insufficient privileges to write to MacPorts install prefix.
```