### PR TITLE
Update JetBrains tools

### DIFF
--- a/content/de-DE/learn/tools.smd
+++ b/content/de-DE/learn/tools.smd
@@ -34,7 +34,5 @@ Editor-spezifische Werkzeuge oder Erweiterungen, meist Syntax-Highlighter.
 
 ## JetBrains-Familie ( IntelliJ IDEA, Fleet und weitere)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/en-US/learn/tools.smd
+++ b/content/en-US/learn/tools.smd
@@ -32,7 +32,7 @@ Editor-specific tools, mostly syntax highlighters.
 ## Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-## JetBrains family ( IntelliJ IDEA, Fleet and etc)
+## JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/en-US/learn/tools.smd
+++ b/content/en-US/learn/tools.smd
@@ -34,7 +34,5 @@ Editor-specific tools, mostly syntax highlighters.
 
 ## JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/it-IT/learn/tools.smd
+++ b/content/it-IT/learn/tools.smd
@@ -34,7 +34,5 @@ Strumenti specifici per gli editor di testo, principalmente per evidenziare la s
 
 ## Famiglia JetBrains (IntelliJ IDEA, Fleet e altri)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/ja-JP/learn/tools.smd
+++ b/content/ja-JP/learn/tools.smd
@@ -34,7 +34,5 @@
 
 ## JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/ja-JP/learn/tools.smd
+++ b/content/ja-JP/learn/tools.smd
@@ -32,7 +32,7 @@
 ## Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-## JetBrains family ( IntelliJ IDEA, Fleet and etc)
+## JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/uk-UA/learn/tools.smd
+++ b/content/uk-UA/learn/tools.smd
@@ -34,6 +34,4 @@
 
 ## JetBrains family (IntelliJ IDEA, Fleet і так далі)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)

--- a/content/zh-CN/learn/tools.smd
+++ b/content/zh-CN/learn/tools.smd
@@ -34,7 +34,5 @@
 
 ## JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/content/zh-CN/learn/tools.smd
+++ b/content/zh-CN/learn/tools.smd
@@ -32,7 +32,7 @@
 ## Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-## JetBrains family ( IntelliJ IDEA, Fleet and etc)
+## JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.ar.md
+++ b/old-content/learn/tools.ar.md
@@ -28,7 +28,7 @@ toc: true
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.ar.md
+++ b/old-content/learn/tools.ar.md
@@ -30,9 +30,7 @@ toc: true
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## الوثائق والاختبارات
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.en.md
+++ b/old-content/learn/tools.en.md
@@ -30,9 +30,7 @@ Editor-specific tools, mostly syntax highlighters.
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 
 ## Documentation and Testing

--- a/old-content/learn/tools.en.md
+++ b/old-content/learn/tools.en.md
@@ -28,7 +28,7 @@ Editor-specific tools, mostly syntax highlighters.
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.es.md
+++ b/old-content/learn/tools.es.md
@@ -28,7 +28,7 @@ Herramientas para editores específicos, principalmente marcadores de sintaxis.
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.es.md
+++ b/old-content/learn/tools.es.md
@@ -30,9 +30,7 @@ Herramientas para editores específicos, principalmente marcadores de sintaxis.
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 
 ## Pruebas y documentación

--- a/old-content/learn/tools.fa.md
+++ b/old-content/learn/tools.fa.md
@@ -28,7 +28,7 @@ toc: true
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.fa.md
+++ b/old-content/learn/tools.fa.md
@@ -30,9 +30,7 @@ toc: true
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## Documentation and Testing
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.fr.md
+++ b/old-content/learn/tools.fr.md
@@ -29,7 +29,7 @@ Outils pour des éditeurs de code spécifiques, principalement pour la coloratio
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.fr.md
+++ b/old-content/learn/tools.fr.md
@@ -31,9 +31,7 @@ Outils pour des éditeurs de code spécifiques, principalement pour la coloratio
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## Documentation et tests
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.id.md
+++ b/old-content/learn/tools.id.md
@@ -28,7 +28,7 @@ Tool khusus untuk editor, sebagian besar syntax highlighter.
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.id.md
+++ b/old-content/learn/tools.id.md
@@ -30,9 +30,7 @@ Tool khusus untuk editor, sebagian besar syntax highlighter.
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## Dokumentasi dan Pengujian
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.ko.md
+++ b/old-content/learn/tools.ko.md
@@ -28,7 +28,7 @@ toc: true
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.ko.md
+++ b/old-content/learn/tools.ko.md
@@ -30,9 +30,7 @@ toc: true
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## 문서화 및 테스트
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.pt.md
+++ b/old-content/learn/tools.pt.md
@@ -28,7 +28,7 @@ Ferramentas específicas do editor, em sua maioria marcadores de sintaxe.
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.pt.md
+++ b/old-content/learn/tools.pt.md
@@ -30,9 +30,7 @@ Ferramentas específicas do editor, em sua maioria marcadores de sintaxe.
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## Documentação e Teste
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.ru.md
+++ b/old-content/learn/tools.ru.md
@@ -28,7 +28,7 @@ toc: true
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 

--- a/old-content/learn/tools.ru.md
+++ b/old-content/learn/tools.ru.md
@@ -30,9 +30,7 @@ toc: true
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## Документация и тестирование
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.tr.md
+++ b/old-content/learn/tools.tr.md
@@ -31,9 +31,7 @@ Dil sunucuları, sözdizimi vurgulaması, otomatik tamamlama ve birçok diğer �
 
 ### JetBrains family ( IntelliJ IDEA, Fleet and etc)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
-- [ZigLang](https://plugins.jetbrains.com/plugin/17143-ziglang)
-- [ZigSupport](https://plugins.jetbrains.com/plugin/18062-zig-support)
-- [Zig](https://plugins.jetbrains.com/plugin/10560-zig)
+- [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 
 ## Belgelendirme ve Test
 - [kristoff-it/zig-doctest](https://github.com/kristoff-it/zig-doctest)

--- a/old-content/learn/tools.tr.md
+++ b/old-content/learn/tools.tr.md
@@ -29,7 +29,7 @@ Dil sunucuları, sözdizimi vurgulaması, otomatik tamamlama ve birçok diğer �
 ### Kate
 - [ziglang/kde-syntax-highlighting](https://github.com/ziglang/kde-syntax-highlighting)
 
-### JetBrains family ( IntelliJ IDEA, Fleet and etc)
+### JetBrains family (IntelliJ IDEA, Fleet)
 - [ZigBrains](https://plugins.jetbrains.com/plugin/22456-zigbrains)
 - [Zig Fleet Plugin](https://plugins.jetbrains.com/plugin/26070-zig)
 


### PR DESCRIPTION
We've got a new [support for Zig in Fleet](https://blog.jetbrains.com/fleet/2024/12/fleet-1-44-is-here-with-new-ui-zig-language-support-and-more-enhancements/), worth mentioning in Zig documentation.

Also, I've checked that most of the IntelliJ plugins haven't been updated for about a year, so you can't even download them for the latest IDE releases. This information is misleading, so maybe we could remove these?