### PR TITLE
Typo fix in overview.smd

### DIFF
--- a/content/en-US/learn/overview.smd
+++ b/content/en-US/learn/overview.smd
@@ -258,7 +258,7 @@ user	0m0.018s
 sys	0m0.009s
 ```
 
-This is thanks to [Build Artifact Caching](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching). Zig automatically parses the .d file uses a robust caching system to avoid duplicating work.
+This is thanks to [Build Artifact Caching](https://ziglang.org/download/0.4.0/release-notes.html#Build-Artifact-Caching). Zig automatically parses the .d file using a robust caching system to avoid duplicating work.
 
 Not only can Zig compile C code, but there is a very good reason to use Zig as a C compiler: [Zig ships with libc](#zig-ships-with-libc).
 


### PR DESCRIPTION
Please confirm that I got the intention right. (Maybe only "parses" or "uses" was meant to stay?)