### PR TITLE
Add .gitattributes to enforce LF for zig/zon files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.zig text eol=lf
+*.zon text eol=lf


### PR DESCRIPTION
Fixes docgen "missing manifest comment" errors on Windows due to autocrlf.