### PR TITLE
fix(docs): update hello-world.zig for Windows compatibility

### DIFF
--- a/assets/zig-code/samples/hello-world.zig
+++ b/assets/zig-code/samples/hello-world.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
-const stdout = std.io.getStdOut().writer();
 
 pub fn main() !void {
-   try stdout.print("hello world!\n", .{});
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("hello world!\n", .{});
 }
 
 // exe=succeed
-


### PR DESCRIPTION
### Description

Fixes: [issue #438](https://github.com/ziglang/www.ziglang.org/issues/438)

### Reference

- Hello World sample doesn't work in Windows [(Issue #438)](https://github.com/ziglang/www.ziglang.org/issues/438)
- Declaring a const variable outside the main function fails on target x86_64-windows-gnu [(Issue #6845)](https://github.com/ziglang/zig/issues/6845#issuecomment-717607368)
- 
### TL;DR

`getStdOut()` only works at runtime on Windows. This is resolved by moving the `getStdOut()` call into the main function's scope. Additionally, [`ziggzagg.zig`](https://ziglang.org/learn/samples/#zigg-zagg) example on the same page uses the correct approach.