### PR TITLE
Change errors switch example into zig test output

### DIFF
--- a/assets/zig-code/features/15-errors-switch.zig
+++ b/assets/zig-code/features/15-errors-switch.zig
@@ -32,4 +32,4 @@ fn charToDigit(c: u8) !u8 {
     return value;
 }
 
-// exe=build_fail
+// test_safety=possibilities


### PR DESCRIPTION
This example was being built via zig build-exe but is written as a zig test example. The output on the website is an error about not having a main function instead of an error about not specifying all possibilities of an error in a switch.

![image](https://github.com/user-attachments/assets/8160a8dd-a4a4-45b8-8358-3c09ba764014)

Closes #400
Closes #425 