### PR TITLE
Fix overhang on mobile in 0.14.0 release notes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -155,6 +155,12 @@ code {
   direction: ltr;
 }
 
+code {
+  overflow-x: auto;
+  display: inline-block;
+  max-width: 100%;
+}
+
 pre > code,
 samp {
   display: block;


### PR DESCRIPTION
Congrats on the latest release!

I tried reading the release announcement on a Pixel 7a, and the rendering leaves a lot of whitespace due to one long hash:

![Image](https://github.com/user-attachments/assets/8d2a0fa6-3e68-422e-8afa-4c442bf95b04)

I believe these CSS changes should fix the overhang.

I am not able to verify that this fix fixes the issue, as I'm not able to get the release notes to render at all when I run `zig build serve` locally. I can get most of the site to serve, but on my dev system, hardcodes the release notes to `https://ziglang.org/download/0.14.0/release-notes.html` rather than the `http://127.0.0.1:1990` domain.

If I manually replace the domain and construct a URL as `http://127.0.0.1:1990/download/0.14.0/release-notes.html`, I get a 404 even though other pages work.