### PR TITLE
Fix download links for Zig 0.14.0 in index.json

### DIFF
--- a/.github/workflows/index.json
+++ b/.github/workflows/index.json
@@ -81,72 +81,72 @@
     "stdDocs": "https://ziglang.org/documentation/0.14.0/std/",
     "notes": "https://ziglang.org/download/0.14.0/release-notes.html",
     "src": {
-      "tarball": "https://ziglang.org/builds/zig-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-0.14.0.tar.xz",
       "shasum": "c76638c03eb204c4432ae092f6fa07c208567e110fbd4d862d131a7332584046",
       "size": "17772188"
     },
     "bootstrap": {
-      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-bootstrap-0.14.0.tar.xz",
       "shasum": "bf3fcb22be0b83f4791748adb567d3304779d66d7bf9b1bd557ef6c2e0232807",
       "size": "48029040"
     },
     "x86_64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-macos-x86_64-0.14.0.tar.xz",
       "shasum": "685816166f21f0b8d6fc7aa6a36e91396dcd82ca6556dfbe3e329deffc01fec3",
       "size": "51039964"
     },
     "aarch64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-macos-aarch64-0.14.0.tar.xz",
       "shasum": "b71e4b7c4b4be9953657877f7f9e6f7ee89114c716da7c070f4a238220e95d7e",
       "size": "45902412"
     },
     "x86_64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz",
       "shasum": "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982",
       "size": "49091960"
     },
     "aarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-aarch64-0.14.0.tar.xz",
       "shasum": "ab64e3ea277f6fc5f3d723dcd95d9ce1ab282c8ed0f431b4de880d30df891e4f",
       "size": "44922728"
     },
     "armv7a-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-armv7a-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-armv7a-0.14.0.tar.xz",
       "shasum": "a67dbfa9bdf769228ec994f2098698c619f930883ca5ef638f50eee2d7788d10",
       "size": "46112980"
     },
     "riscv64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-riscv64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-riscv64-0.14.0.tar.xz",
       "shasum": "a2b14d3de326d3fd095548ef38bf5a67b15dadd62fbcc90836d63cc4355f8ef7",
       "size": "48069188"
     },
     "powerpc64le-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-powerpc64le-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-powerpc64le-0.14.0.tar.xz",
       "shasum": "3eabd60876ebc2748de8eb57b4b8cfa78861ba9bf7c6dd83f4e3e1d271d7c45e",
       "size": "48707620"
     },
     "x86-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-x86-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-x86-0.14.0.tar.xz",
       "shasum": "55d1ba21de5109686ffa675b9cc1dd66930093c202995a637ce3e397816e4c08",
       "size": "51621460"
     },
     "loongarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-loongarch64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-loongarch64-0.14.0.tar.xz",
       "shasum": "31a2f07df55f8f528b92d540db9aae6c0b38643c34dc1ac33a0111d855e996ae",
       "size": "45821860"
     },
     "x86_64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-windows-x86_64-0.14.0.zip",
       "shasum": "f53e5f9011ba20bbc3e0e6d0a9441b31eb227a97bac0e7d24172f1b8b27b4371",
       "size": "82219809"
     },
     "aarch64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-windows-aarch64-0.14.0.zip",
       "shasum": "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046",
       "size": "78113283"
     },
     "x86-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-x86-0.14.0.zip",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-windows-x86-0.14.0.zip",
       "shasum": "1a867d808cf4fa9184358395d94441390b6b24ee8d00d356ca11ea7cbfd3a4ec",
       "size": "83970029"
     }

--- a/assets/download/index.json
+++ b/assets/download/index.json
@@ -81,72 +81,72 @@
     "stdDocs": "https://ziglang.org/documentation/0.14.0/std/",
     "notes": "https://ziglang.org/download/0.14.0/release-notes.html",
     "src": {
-      "tarball": "https://ziglang.org/builds/zig-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-0.14.0.tar.xz",
       "shasum": "c76638c03eb204c4432ae092f6fa07c208567e110fbd4d862d131a7332584046",
       "size": "17772188"
     },
     "bootstrap": {
-      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-bootstrap-0.14.0.tar.xz",
       "shasum": "bf3fcb22be0b83f4791748adb567d3304779d66d7bf9b1bd557ef6c2e0232807",
       "size": "48029040"
     },
     "x86_64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-macos-x86_64-0.14.0.tar.xz",
       "shasum": "685816166f21f0b8d6fc7aa6a36e91396dcd82ca6556dfbe3e329deffc01fec3",
       "size": "51039964"
     },
     "aarch64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-macos-aarch64-0.14.0.tar.xz",
       "shasum": "b71e4b7c4b4be9953657877f7f9e6f7ee89114c716da7c070f4a238220e95d7e",
       "size": "45902412"
     },
     "x86_64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz",
       "shasum": "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982",
       "size": "49091960"
     },
     "aarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-aarch64-0.14.0.tar.xz",
       "shasum": "ab64e3ea277f6fc5f3d723dcd95d9ce1ab282c8ed0f431b4de880d30df891e4f",
       "size": "44922728"
     },
     "armv7a-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-armv7a-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-armv7a-0.14.0.tar.xz",
       "shasum": "a67dbfa9bdf769228ec994f2098698c619f930883ca5ef638f50eee2d7788d10",
       "size": "46112980"
     },
     "riscv64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-riscv64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-riscv64-0.14.0.tar.xz",
       "shasum": "a2b14d3de326d3fd095548ef38bf5a67b15dadd62fbcc90836d63cc4355f8ef7",
       "size": "48069188"
     },
     "powerpc64le-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-powerpc64le-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-powerpc64le-0.14.0.tar.xz",
       "shasum": "3eabd60876ebc2748de8eb57b4b8cfa78861ba9bf7c6dd83f4e3e1d271d7c45e",
       "size": "48707620"
     },
     "x86-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-x86-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-x86-0.14.0.tar.xz",
       "shasum": "55d1ba21de5109686ffa675b9cc1dd66930093c202995a637ce3e397816e4c08",
       "size": "51621460"
     },
     "loongarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-loongarch64-0.14.0.tar.xz",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-linux-loongarch64-0.14.0.tar.xz",
       "shasum": "31a2f07df55f8f528b92d540db9aae6c0b38643c34dc1ac33a0111d855e996ae",
       "size": "45821860"
     },
     "x86_64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0.zip",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-windows-x86_64-0.14.0.zip",
       "shasum": "f53e5f9011ba20bbc3e0e6d0a9441b31eb227a97bac0e7d24172f1b8b27b4371",
       "size": "82219809"
     },
     "aarch64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0.zip",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-windows-aarch64-0.14.0.zip",
       "shasum": "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046",
       "size": "78113283"
     },
     "x86-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-x86-0.14.0.zip",
+      "tarball": "https://ziglang.org/download/0.14.0/zig-windows-x86-0.14.0.zip",
       "shasum": "1a867d808cf4fa9184358395d94441390b6b24ee8d00d356ca11ea7cbfd3a4ec",
       "size": "83970029"
     }


### PR DESCRIPTION
Fixes #456 .
This PR updates the download links for Zig 0.14.0 in index.json.