### PR TITLE
Update sample code example: generic-type.zig - use self/Self instead of this/This

### DIFF
--- a/assets/zig-code/samples/generic-type.zig
+++ b/assets/zig-code/samples/generic-type.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn Queue(comptime Child: type) type {
     return struct {
-        const This = @This();
+        const Self = @This();
         const Node = struct {
             data: Child,
             next: ?*Node,
@@ -11,28 +11,28 @@ pub fn Queue(comptime Child: type) type {
         start: ?*Node,
         end: ?*Node,
 
-        pub fn init(gpa: std.mem.Allocator) This {
-            return This{
+        pub fn init(gpa: std.mem.Allocator) Self {
+            return Self{
                 .gpa = gpa,
                 .start = null,
                 .end = null,
             };
         }
-        pub fn enqueue(this: *This, value: Child) !void {
-            const node = try this.gpa.create(Node);
+        pub fn enqueue(self: *Self, value: Child) !void {
+            const node = try self.gpa.create(Node);
             node.* = .{ .data = value, .next = null };
-            if (this.end) |end| end.next = node //
-            else this.start = node;
-            this.end = node;
+            if (self.end) |end| end.next = node //
+            else self.start = node;
+            self.end = node;
         }
-        pub fn dequeue(this: *This) ?Child {
-            const start = this.start orelse return null;
-            defer this.gpa.destroy(start);
+        pub fn dequeue(self: *Self) ?Child {
+            const start = self.start orelse return null;
+            defer self.gpa.destroy(start);
             if (start.next) |next|
-                this.start = next
+                self.start = next
             else {
-                this.start = null;
-                this.end = null;
+                self.start = null;
+                self.end = null;
             }
             return start.data;
         }


### PR DESCRIPTION
In following what seems to be a more idiomatic Zig best practice this PR simply changes this/This -> self/Self to refer to the inline struct for the generic Queue sample code.