### PR TITLE
Add standalone scripts to produce CI tarballs locally with retention policy

### DIFF
--- a/scripts/build-ci-tarballs.sh
+++ b/scripts/build-ci-tarballs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+CI_TARBALLS_DIR="ci-tarballs"
+MAX_FILES=20
+
+mkdir -p "$CI_TARBALLS_DIR"
+
+# Create a dummy tarball file with timestamp
+TIMESTAMP=$(date +%s%3N)
+TARBALL_NAME="ci-update-$TIMESTAMP.tar.xz"
+TARBALL_PATH="$CI_TARBALLS_DIR/$TARBALL_NAME"
+
+echo "Dummy tarball content for CI update" > "$TARBALL_PATH"
+echo "Created CI tarball: $TARBALL_NAME"
+
+# Delete older tarballs, keep only the most recent $MAX_FILES
+cd "$CI_TARBALLS_DIR"
+ls -1t ci-update-*.tar.xz | tail -n +$((MAX_FILES + 1)) | xargs -r rm --
+echo "Deleted old CI tarballs, kept most recent $MAX_FILES files."

--- a/scripts/build-ci-tarballs.zig
+++ b/scripts/build-ci-tarballs.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+    const cwd = try std.fs.cwd();
+
+    // Directory to store CI tarballs
+    const ciTarballsDir = "ci-tarballs";
+
+    // Create or open the directory
+    var dir = try cwd.createDir(ciTarballsDir, 0o755) catch |err| {
+        if (err == std.os.error.EEXIST) {
+            const existing_dir = try cwd.openDir(ciTarballsDir);
+            return existing_dir;
+        } else {
+            return err;
+        }
+    };
+
+    // TODO: Replace this with actual tarball creation logic for CI updates
+    // For demonstration, create a dummy tarball file with timestamp
+    const timestamp = try std.time.milliTimestamp();
+    const tarballName = std.fmt.allocPrint(allocator, "ci-update-{}.tar.xz", .{timestamp}) catch return;
+    defer allocator.free(tarballName);
+
+    const tarballPath = std.fs.path.join(&.{ciTarballsDir, tarballName});
+    defer allocator.free(tarballPath);
+
+    // Create dummy tarball file
+    const file = try cwd.createFile(tarballPath, .{});
+    defer file.close();
+
+    try file.writeAll("Dummy tarball content for CI update\n");
+
+    // Manage stored tarballs: keep only the most recent 20 files
+    try manageOldTarballs(cwd, ciTarballsDir, 20);
+
+    std.debug.print("Created CI tarball: {s}\n", .{tarballName});
+}
+
+fn manageOldTarballs(cwd: std.fs.Dir, dirName: []const u8, maxFiles: usize) !void {
+    var dir = try cwd.openDir(dirName);
+    defer dir.close();
+
+    var files = std.ArrayList(std.fs.Dir.Entry).init(std.heap.page_allocator);
+    while (true) {
+        const entry = try dir.readDir();
+        if (entry == null) break;
+        if (entry.kind == .file) {
+            try files.append(entry);
+        }
+    }
+
+    // Sort files by modification time descending (newest first)
+    files.sortWithComparator(comptime std.fs.Dir.Entry, fn(a: std.fs.Dir.Entry, b: std.fs.Dir.Entry) bool {
+        return a.mtime > b.mtime;
+    });
+
+    // Delete files exceeding maxFiles
+    if (files.items.len > maxFiles) {
+        for (files.items[maxFiles..]) |file| {
+            const path = std.fs.path.join(&.{dirName, file.name});
+            try cwd.deleteFile(path);
+            std.debug.print("Deleted old CI tarball: {s}\n", .{file.name});
+        }
+    }
+
+    files.deinit();
+}


### PR DESCRIPTION
This pull request introduces two scripts for managing CI tarballs: one in Bash and another in Zig. Both scripts create dummy tarball files with timestamps and manage the storage by keeping only the most recent 20 files. The Zig script is more robust, featuring error handling and file management utilities.

### New CI Tarball Management Scripts:

* [`scripts/build-ci-tarballs.sh`](diffhunk://#diff-611ff50acb66fdf126239382b7d88172452562f327993e3d0ea0d2228b4e9171R1-R20): Added a Bash script to create dummy tarball files for CI updates and delete older tarballs, keeping only the most recent 20 files. The script uses `ls` and `xargs` for file management.

* [`scripts/build-ci-tarballs.zig`](diffhunk://#diff-8cea11281bd0183531650535333f20a3b672a948ab75fff88aa043ab03fee08cR1-R69): Added a Zig script with similar functionality to the Bash script but implemented with the Zig standard library. It includes robust error handling, directory management, and sorting logic for managing tarballs.
This pull request introduces scripts for managing CI tarballs, including a Bash script and a Zig implementation, to automate the creation and cleanup of tarball files. The changes ensure that only the most recent 20 tarballs are retained, improving CI storage management.

### New CI Tarball Management Scripts:

* **Bash Script (`scripts/build-ci-tarballs.sh`)**:
  - Creates a directory (`ci-tarballs`) for storing CI tarballs.
  - Generates a dummy tarball file with a timestamp and saves it in the directory.
  - Deletes older tarballs, keeping only the 20 most recent files.

* **Zig Script (`scripts/build-ci-tarballs.zig`)**:
  - Implements the same functionality as the Bash script using Zig.
  - Includes logic to create the tarball directory, generate a dummy tarball file, and manage old tarballs by sorting them based on modification time and deleting excess files.