### PR TITLE
fix a typo in Special-Root-Declarations

### DIFF
--- a/src/documentation/0.14.0/index.html
+++ b/src/documentation/0.14.0/index.html
@@ -13744,7 +13744,7 @@ bar: <span class="tok-type">u64</span>,
 
       <p>
       Because the root module's root source file is always accessible using
-      <code><span class="tok-builtin">@import</span>(<span class="tok-str">&quot;root&quot;</span>)</code>, is is sometimes used by libraries &mdash; including the Zig Standard
+      <code><span class="tok-builtin">@import</span>(<span class="tok-str">&quot;root&quot;</span>)</code>, it is sometimes used by libraries &mdash; including the Zig Standard
       Library &mdash; as a place for the program to expose some "global" information to that library. The Zig
       Standard Library will look for several declarations in this file.
       </p>

--- a/src/documentation/0.14.1/index.html
+++ b/src/documentation/0.14.1/index.html
@@ -13762,7 +13762,7 @@ bar: <span class="tok-type">u64</span>,
 
       <p>
       Because the root module's root source file is always accessible using
-      <code><span class="tok-builtin">@import</span>(<span class="tok-str">&quot;root&quot;</span>)</code>, is is sometimes used by libraries &mdash; including the Zig Standard
+      <code><span class="tok-builtin">@import</span>(<span class="tok-str">&quot;root&quot;</span>)</code>, it is sometimes used by libraries &mdash; including the Zig Standard
       Library &mdash; as a place for the program to expose some "global" information to that library. The Zig
       Standard Library will look for several declarations in this file.
       </p>


### PR DESCRIPTION
a typo, i guess ", is is" should be ", it is"

<img width="812" alt="截屏2025-06-17 14 32 27" src="https://github.com/user-attachments/assets/a37ba9de-c440-40cb-b189-9b9802ce894c" />
