### PR TITLE
Mirrors!

### DIFF
--- a/.github/workflows/check-mirrors.yml
+++ b/.github/workflows/check-mirrors.yml
@@ -1,0 +1,28 @@
+name: Check Mirrors
+on:
+  schedule: [{ cron: "0 22 * * *" }]
+  workflow_dispatch: null
+  pull_request: { paths: ["assets/community-mirrors.ziggy"] }
+jobs:
+  check:
+    runs-on: [self-hosted, website]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check Mirrors
+        run: |
+          cd check-mirrors
+          /home/ci/deps/zig-linux-x86_64-0.14.0/zig build run -- ../assets/community-mirrors.ziggy "$GITHUB_STEP_SUMMARY"
+  notify-failure:
+    runs-on: [self-hosted, website]
+    needs: [check]
+    if: ${{ always() && (needs.check.result == 'failure' || needs.check.result == 'timed_out') }}
+    steps:
+      - name: Send Notification
+        env:
+          PUSHOVER_USER: ${{ secrets.MIRROR_CHECK_PUSHOVER_USER }}
+          PUSHOVER_TOKEN: ${{ secrets.MIRROR_CHECK_PUSHOVER_TOKEN }}
+        run: curl -s
+               -F user="$PUSHOVER_USER"
+               -F token="$PUSHOVER_TOKEN"
+               -F message="Zig download mirror validation failed"
+               https://api.pushover.net/1/messages.json

--- a/MIRRORS.md
+++ b/MIRRORS.md
@@ -1,0 +1,95 @@
+> [!NOTE]
+> Are you trying to download Zig from a mirror? If so, you're in the wrong place! This documentation is for anyone who wants to *host* a community mirror.
+> For instructions on *using* the mirrors, check out the [Community Mirrors](https://ziglang.org/download/community-mirrors/) page on the Zig website.
+
+# Community Mirrors
+
+The Zig mirrors in this repository are all community-maintained and unaffiliated with the ZSF. Anyone is welcome to host their own mirror and add it to the
+list. Because Zig's tarballs are cryptographically signed, no mirror need be trusted. Of course, if a mirror is found to be malicious, it will be removed from
+the list.
+
+The following rules define how a mirror works and the requirements it is expected to fulfil.
+
+* A mirror provides a single base URL, which we will call `X`.
+* `X` **may** include a path component, but is not required to. For instance, `https://foo.bar/zig/` is okay,
+  as is `https://zig.baz.qux/`.
+* The mirror **must** support HTTPS with a valid signed certificate. `X` **must** start with `https://`.
+* The mirror **must** cache tarballs locally. For instance, it may not simply forward all requests to another mirror.
+* The mirror **may** routinely evict its local tarball caches based on any reasonable factor, such as age, access frequency, or the existence of newer versions. This does not affect whether the mirror may respond with 404 Not Found for requests to these files (see below).
+* The mirror **must** download tarballs from `https://ziglang.org/` or a valid mirror of it.
+  * Typically, it is best to download only from `https://ziglang.org/`. One possible exception is when a pre-release is requested which is more likely to be available from an alternative mirror.
+* When a mirror receives a GET request for `X/<filename>`, the behavior depends on `<filename>`.
+  * Parse the file name to extract the Zig version string. More details on this are [below](#parsing-versions).
+  * Determine whether this is a "normal" or "pre-release" [Semantic Version](https://semver.org/).
+  * If this is a "normal" version, respond with 200 OK and the file found at `https://ziglang.org/download/<version>/<filename>`.
+    * If the release version is "0.5.0" or older (according to Semantic Versioning), the mirror **may** respond with 404 Not Found, but is not required to.
+    * Otherwise, the mirror **must** return the tarball.
+    * These requirements apply equally to source tarballs (e.g. `zig-0.14.1.tar.xz`), bootstrap source tarballs (e.g. `zig-bootstrap-0.14.1.tar.xz`), and binary tarballs (e.g. `zig-x86_64-linux-0.14.1.tar.xz`).
+  * Otherwise (i.e. if this is a "pre-release" version), respond with 200 OK and the file found at `https://ziglang.org/builds/<filename>`.
+    * If the version is older than the latest "release" version (according to Semantic Versioning), the mirror **may** respond with 404 Not Found, but is not required to.
+    * Otherwise, the mirror **must** return the tarball.
+    * These requirements apply equally to source tarballs (e.g. `zig-0.15.0-dev.671+c907866d5.tar.xz`), bootstrap source tarballs (e.g. `zig-bootstrap-0.15.0-dev.671+c907866d5.tar.xz`), and binary tarballs (e.g. `zig-x86_64-linux-0.15.0-dev.671+c907866d5.tar.xz`).
+  * Invalid accesses, for instance to malformed filenames, **may** cause a 404 Not Found response.
+  * Accesses to file names which do not end with ".zip", ".tar.xz", ".zip.minisig", or ".tar.xz.minisig", **may** cause a 404 Not Found response.
+* Files provided by the mirror **must** be bit-for-bit identical to their `https://ziglang.org/` counterparts.
+* If a mirror is required to serve a tarball which is has not yet cached locally, it **must** immediately download it from its source at `https://ziglang.org`, and respond with that downloaded file.
+* The mirror **may** rate-limit accesses. If an access failed due to rate-limiting, the mirror **should** respond with 429 Too Many Requests.
+* The mirror **may** undergo maintenance, upgrades, and other scheduled downtime. If an access fails for this reason, where possible, the mirror **should** respond with 503 Unavailable. The mirror **should** try to minimize such downtime.
+* The mirror **may** undergo occasional unintended and unscheduled downtime. The mirror **must** go to all efforts to minimize such outages, and **must** resolve such outages within a reasonable time upon being notified of them.
+* The mirror **may** observe the query parameter named `source` to learn about the origin of its traffic.
+  * Clients are encouraged, but not required, to provide this query parameter to indicate what service triggered the request. For instance, the `mlugg/setup-zig` GitHub Action passes this query parameter as `?source=github-mlugg-setup-zig`.
+
+## Parsing Versions
+
+Mirrors are required to parse tarball file names to extract the Zig version from them. Unfortunately,
+this is complicated a little by two factors: the existence of "source" tarballs, and the fact that
+Zig's tarball naming schema changed with the 0.14.1 release.
+
+If you have access to Regular Expressions, a simple strategy is to search the tarball name for
+`/\d+\.\d+\.\d+(-dev\.\d+\+[0-9a-f]+)?/`. This is probably inefficient, but that is unlikely to
+matter in practice.
+
+An alternative strategy which is simpler but requires slightly more code is as follows:
+* Strip a supported extension (`.zip`, `.tar.xz`, `.zip.minisig`, `.tar.xz.minisig`) from the end of the file name.
+* Find the last occurrence of "-" in the file name. If that byte is followed by the string "dev", find the previous occurence of "-" instead.
+* The string after that "-" byte is the Zig version.
+
+It is strongly discouraged for checks to rely on specific architecture or OS names, since the set of targets for which tarballs are provided could be extended at any time.
+
+## Adding A Mirror
+
+Once a mirror complies with the requirements listed above, you can add it to the list of mirrors on ziglang.org by modifying the list in
+`assets/community-mirrors.ziggy` and opening a pull request with your changes. The diff should just add a single entry to the end of the list:
+
+```diff
+ [
+     {
+         .url = "https://a.com",
+         .username = "a",
+         .email = "a@a.com",
+     },
+     {
+         .url = "https://b.com/zig",
+         .username = "b",
+         .email = "b@b.com",
+     },
++    {
++        .url = "https://mymirror.net",
++        .username = "my-github-username",
++        .email = "my@email.com",
++    },
+ ]
+```
+
+Note that the Zig core team always reserves the right to exclude mirrors from this list for any (or no) reason.
+
+## Community-Written Solutions
+
+Some members of the Zig community have written software for hosting Zig mirrors, making it easier to comply with the requirements listed above. If you have an
+open-source repository which would fit here, feel free to open a pull request adding it below.
+
+> [!WARNING]
+> The Zig Software Foundation has not written or audited this code. As such, no guarantees can be made regarding its correctness, and it should **not** be
+> implicitly trusted. You are strongly encouraged to audit this software before using it, particularly if it will not be run in an isolated environment.
+
+* [hexops/wrench](https://github.com/hexops/wrench?tab=readme-ov-file#run-your-own-ziglangorgdownload-mirror)

--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -1,0 +1,17 @@
+[
+    {
+        .url = "https://pkg.machengine.org/zig",
+        .username = "emidoots",
+        .email = "emi@hexops.com",
+    },
+    {
+        .url = "https://zigmirror.hryx.net/zig",
+        .username = "hryx",
+        .email = "codroid@gmail.com",
+    },
+    {
+        .url = "https://zig.linus.dev/zig",
+        .username = "linusg",
+        .email = "mail@linusgroh.de",
+    },
+]

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -467,7 +467,7 @@ blockquote {
 }
 
 
-code.zig {
+code {
   --light-yellow: #e5c07b;
   --dark-yellow: #d19a66;
   --blue: #61afef;
@@ -516,4 +516,50 @@ video {
 #back {
   margin-top: 1em;
   display: inline-block;
+}
+
+code.python {
+  color: var(--cyan);
+}
+
+code.python .punctuation {
+  color: var(--cyan);
+}
+
+code.python .string {
+  color: var(--dark-yellow);
+}
+
+code.python .variable,
+code.python .parameter,
+code.python .exception,
+code.python .field {
+  color: var(--light-yellow);
+}
+
+code.python .keyword.function {
+  color: var(--light-red);
+}
+
+code.python .bracket {
+  color: var(--cyan);
+}
+
+code.python .function {
+  color: var(--blue);
+}
+
+code.python .builtin {
+  color: var(--magenta);
+}
+
+code.python .number {
+  color: var(--magenta);
+}
+
+code.python .operator,
+code.python .qualifier,
+code.python .keyword,
+code.python .attribute {
+  color: var(--light-red);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "doctest-0.1.0-lY-6k0W2AQB2cw2vD3306oCziQrVnG013naZd8hMkuAQ",
         },
         .zine = .{
-            .url = "git+https://github.com/kristoff-it/zine#5408d3dff6107fc449a6d24d90f379b6fffdb4e6",
-            .hash = "zine-0.9.0-ou6nIBcqFgCkkL8OQnHRzEKboVcAvIp76bnf6n9qeBvU",
+            .url = "git+https://github.com/kristoff-it/zine#ff0b7b1222fe6529fc36e876a71a99379ad761c4",
+            .hash = "zine-0.9.0-ou6nIEJTFgDwdlQnB6NtTnZneWKgg-qoVPaXyU2PjWF2",
         },
     },
 }

--- a/check-mirrors/README.md
+++ b/check-mirrors/README.md
@@ -1,0 +1,8 @@
+# check-mirrors
+
+This is a small utility which checks the functionality of all listed community mirrors. It does this
+by fetching a subset of available tarballs and signatures from each mirror, and checking that the
+returned files exactly match the corresponding files served by ziglang.org.
+
+This check is automatically run once per day by the 'check-mirrors' workflow. It also runs when a PR
+modifies the mirror list.

--- a/check-mirrors/build.zig
+++ b/check-mirrors/build.zig
@@ -1,0 +1,28 @@
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const ziggy = b.dependency("ziggy", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "check-mirrors",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "ziggy", .module = ziggy.module("ziggy") },
+            },
+        }),
+    });
+    b.installArtifact(exe);
+
+    const run = b.addRunArtifact(exe);
+    if (b.args) |args| run.addArgs(args);
+    b.step("run", "Run check-mirrors").dependOn(&run.step);
+}
+
+const std = @import("std");

--- a/check-mirrors/build.zig.zon
+++ b/check-mirrors/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .check_mirrors,
+    .version = "0.0.0",
+    .fingerprint = 0xcb408e1ecbee16fd, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.0",
+    .dependencies = .{
+        .ziggy = .{
+            .url = "git+https://github.com/kristoff-it/ziggy.git#fe3bf9389e7ff213cf3548caaf9c6f3d4bb38647",
+            .hash = "ziggy-0.1.0-kTg8vwBEBgDFzbstERaPLr5TzM1DhfDza1we_eEXuLDL",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/check-mirrors/main.zig
+++ b/check-mirrors/main.zig
@@ -1,0 +1,457 @@
+const download_json_url = "https://ziglang.org/download/index.json";
+const release_tarball_template = "https://ziglang.org/download/{s}/{s}";
+const master_tarball_template = "https://ziglang.org/builds/{s}";
+
+/// This is a list of *release* tarballs which will be compared between ziglang.org and each mirror.
+/// As well as this list, we check some tarballs for the latest "master" build: see `master_targets`.
+const tarball_names: []const []const u8 = &.{
+    // TODO: once 0.15.0 is released, add some FreeBSD/NetBSD tarballs!
+
+    // 0.14.1 (new tarball name format, some new targets)
+    "zig-0.14.1.tar.xz",
+    "zig-x86_64-windows-0.14.1.zip",
+    "zig-aarch64-macos-0.14.1.tar.xz",
+    // This is every 'zig-xxx-linux-0.14.1.tar.xz' (same order as on the website)
+    "zig-x86_64-linux-0.14.1.tar.xz",
+    "zig-aarch64-linux-0.14.1.tar.xz",
+    "zig-armv7a-linux-0.14.1.tar.xz",
+    "zig-riscv64-linux-0.14.1.tar.xz",
+    "zig-powerpc64le-linux-0.14.1.tar.xz",
+    "zig-x86-linux-0.14.1.tar.xz",
+    "zig-loongarch64-linux-0.14.1.tar.xz",
+    "zig-s390x-linux-0.14.1.tar.xz",
+
+    // 0.10.1 (last stage1 release)
+    "zig-0.10.1.tar.xz",
+    "zig-bootstrap-0.10.1.tar.xz",
+    "zig-linux-i386-0.10.1.tar.xz",
+    "zig-macos-aarch64-0.10.1.tar.xz",
+    "zig-windows-x86_64-0.10.1.zip",
+
+    // 0.7.1 (oldest supported patch release)
+    "zig-0.7.1.tar.xz",
+    "zig-linux-x86_64-0.7.1.tar.xz",
+
+    // 0.6.0 (oldest supported version)
+    "zig-0.6.0.tar.xz",
+    "zig-linux-x86_64-0.6.0.tar.xz",
+};
+
+/// We don't request *every* build of 'master' from the mirrors; that'd probably cause them to cache
+/// a bunch of tarballs pointlessly. Instead, just request this common-ish subset. We do request all
+/// of the *signatures* though, since they won't use much space in the mirrors' caches and will be
+/// fast to fetch.
+const master_targets: []const []const u8 = &.{
+    "x86_64-linux",
+    "x86_64-freebsd",
+    "x86_64-netbsd",
+    "x86_64-windows",
+    "aarch64-macos",
+    "x86-windows",
+    "armv7a-linux",
+};
+
+const File = struct {
+    name: []const u8,
+    version: ?[]const u8,
+
+    const Result = union(enum) {
+        /// Value is query time in nanoseconds.
+        ok: u64,
+        content_mismatch,
+        bad_status: std.http.Status,
+        err: anyerror,
+
+        pub fn format(res: Result, comptime fmt: []const u8, options: std.fmt.FormatOptions, w: anytype) !void {
+            if (fmt.len != 0) std.fmt.invalidFmtError(fmt, res);
+            _ = options;
+            switch (res) {
+                .ok => |query_ns| try w.print("{}", .{std.fmt.fmtDuration(query_ns)}),
+                .content_mismatch => try w.writeAll(":warning: incorrect contents"),
+                .err => |err| try w.print(":warning: error: {s}", .{@errorName(err)}),
+                .bad_status => |s| try w.print(":warning: bad status: {d} {s}", .{ @intFromEnum(s), s.phrase() orelse "?" }),
+            }
+        }
+    };
+};
+
+const Mirror = struct {
+    url: []const u8,
+    username: []const u8,
+    email: []const u8,
+
+    total_ns: u64,
+    ns_div: u64,
+    file_result: File.Result,
+
+    const Parsed = struct {
+        url: []const u8,
+        username: []const u8,
+        email: []const u8,
+    };
+
+    fn fromParsed(p: Parsed) Mirror {
+        return .{
+            .url = p.url,
+            .username = p.username,
+            .email = p.email,
+            .total_ns = 0,
+            .ns_div = 0,
+            .file_result = undefined,
+        };
+    }
+};
+
+pub fn main() Allocator.Error!u8 {
+    const gpa = std.heap.smp_allocator;
+
+    var arena_state: std.heap.ArenaAllocator = .init(gpa);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const args = std.process.argsAlloc(arena) catch @panic("argsAlloc failed");
+    if (args.len != 3) @panic("usage: check-mirrors <mirrors.ziggy> <out.md>");
+    const mirrors_path = args[1];
+    const out_path = args[2];
+
+    var http_client: std.http.Client = .{ .allocator = gpa };
+    http_client.initDefaultProxies(arena) catch |err| {
+        std.debug.panic("failed to init http client: {s}", .{@errorName(err)});
+    };
+    defer http_client.deinit();
+
+    const mirrors: []Mirror = mirrors: {
+        const raw = std.fs.cwd().readFileAllocOptions(arena, mirrors_path, 1024 * 1024 * 8, null, 1, 0) catch |err| {
+            std.debug.panic("failed to read mirrors file '{s}': {s}", .{ mirrors_path, @errorName(err) });
+        };
+        const parsed = ziggy.parseLeaky([]const Mirror.Parsed, arena, raw, .{}) catch |err| {
+            std.debug.panic("failed to parse mirrors file '{s}': {s}", .{ mirrors_path, @errorName(err) });
+        };
+        const mirrors = try arena.alloc(Mirror, parsed.len);
+        for (mirrors, parsed) |*m, p| m.* = .fromParsed(p);
+        break :mirrors mirrors;
+    };
+
+    const download_json_raw: []const u8 = try httpGetZsf(arena, &http_client, download_json_url);
+    const download_json: std.json.Value = std.json.parseFromSliceLeaky(std.json.Value, arena, download_json_raw, .{}) catch |err| {
+        std.debug.panic("failed to parse download json: {s}", .{@errorName(err)});
+    };
+    const master_tarballs = parseMasterTarballs(arena, &download_json) catch |err| {
+        std.debug.panic("failed to get master build info: {s}", .{@errorName(err)});
+    };
+
+    // allocated into gpa
+    var tarballs: std.ArrayListUnmanaged(File) = .empty;
+    defer tarballs.deinit(gpa);
+    var minisigs: std.ArrayListUnmanaged(File) = .empty;
+    defer minisigs.deinit(gpa);
+
+    {
+        const tarball_name = try std.fmt.allocPrint(arena, "zig-{s}.tar.xz", .{master_tarballs.version});
+        const minisig_name = try std.fmt.allocPrint(arena, "{s}.minisig", .{tarball_name});
+        try tarballs.append(gpa, .{ .name = tarball_name, .version = null });
+        try minisigs.append(gpa, .{ .name = minisig_name, .version = null });
+    }
+    {
+        const tarball_name = try std.fmt.allocPrint(arena, "zig-bootstrap-{s}.tar.xz", .{master_tarballs.version});
+        const minisig_name = try std.fmt.allocPrint(arena, "{s}.minisig", .{tarball_name});
+        try tarballs.append(gpa, .{ .name = tarball_name, .version = null });
+        try minisigs.append(gpa, .{ .name = minisig_name, .version = null });
+    }
+    for (master_tarballs.tar_xz_targets) |target| {
+        const tarball_name = try std.fmt.allocPrint(arena, "zig-{s}-{s}.tar.xz", .{ target, master_tarballs.version });
+        const minisig_name = try std.fmt.allocPrint(arena, "{s}.minisig", .{tarball_name});
+        for (master_targets) |t| {
+            if (std.mem.eql(u8, target, t)) {
+                try tarballs.append(gpa, .{ .name = tarball_name, .version = null });
+                break;
+            }
+        }
+        try minisigs.append(gpa, .{ .name = minisig_name, .version = null });
+    }
+    for (master_tarballs.zip_targets) |target| {
+        const tarball_name = try std.fmt.allocPrint(arena, "zig-{s}-{s}.zip", .{ target, master_tarballs.version });
+        const minisig_name = try std.fmt.allocPrint(arena, "{s}.minisig", .{tarball_name});
+        for (master_targets) |t| {
+            if (std.mem.eql(u8, target, t)) {
+                try tarballs.append(gpa, .{ .name = tarball_name, .version = null });
+                break;
+            }
+        }
+        try minisigs.append(gpa, .{ .name = minisig_name, .version = null });
+    }
+    for (tarball_names) |tarball_name| {
+        const zig_version = releaseTarballVersion(tarball_name);
+        const minisig_name = try std.fmt.allocPrint(arena, "{s}.minisig", .{tarball_name});
+        try tarballs.append(gpa, .{ .name = tarball_name, .version = zig_version });
+        try minisigs.append(gpa, .{ .name = minisig_name, .version = zig_version });
+    }
+
+    std.log.info("{d} mirrors; {d} tarballs; {d} signatures", .{ mirrors.len, tarballs.items.len, minisigs.items.len });
+
+    var root_prog_node = std.Progress.start(.{
+        .root_name = "check",
+        .estimated_total_items = tarballs.items.len + minisigs.items.len,
+    });
+    defer root_prog_node.end();
+    const tarballs_prog_node = root_prog_node.start("tarballs", tarballs.items.len);
+    const minisigs_prog_node = root_prog_node.start("signatures", minisigs.items.len);
+
+    var any_failures = false;
+
+    var out_al: std.ArrayListUnmanaged(u8) = .empty;
+    defer out_al.deinit(gpa);
+    const out = out_al.writer(gpa);
+
+    try out.writeAll("## Tarballs\n\n");
+
+    // Write a table header that looks like this (minus the whitespace on the second line):
+    //   | File Name | Zig Version | @uname1 | @uname2 | @uname3 |
+    //   |-          |-            |-        |-        |-        |
+    try out.writeAll("| File Name | Zig Version |");
+    for (mirrors) |m| try out.print(" @{s} |", .{m.username});
+    try out.writeAll("\n|-|-|");
+    for (mirrors) |_| try out.writeAll("-:|");
+
+    for (tarballs.items) |*file| {
+        const prog_node = tarballs_prog_node.start(file.name, mirrors.len);
+        defer prog_node.end();
+        try checkFile(gpa, arena, &http_client, mirrors, file, prog_node);
+        try out.print("\n| `{s}` | {s} |", .{ file.name, file.version orelse "master" });
+        for (mirrors) |m| {
+            if (m.file_result != .ok) any_failures = true;
+            try out.print(" {} |", .{m.file_result});
+        }
+    }
+    try out.writeAll("\n| **Avg. time** | |");
+    for (mirrors) |*m| {
+        const avg_ns: u64 = if (m.ns_div == 0) 0 else m.total_ns / m.ns_div;
+        try out.print(" {} |", .{std.fmt.fmtDuration(avg_ns)});
+        // Reset for below
+        m.total_ns = 0;
+        m.ns_div = 0;
+    }
+
+    try out.writeAll("\n\n## Signatures\n\n");
+
+    // Same table header as before
+    try out.writeAll("| File Name | Zig Version |");
+    for (mirrors) |m| try out.print(" @{s} |", .{m.username});
+    try out.writeAll("\n|-|-|");
+    for (mirrors) |_| try out.writeAll("-:|");
+
+    for (minisigs.items) |*file| {
+        const prog_node = minisigs_prog_node.start(file.name, mirrors.len);
+        defer prog_node.end();
+        try checkFile(gpa, arena, &http_client, mirrors, file, prog_node);
+        try out.print("\n| `{s}` | {s} |", .{ file.name, file.version orelse "master" });
+        for (mirrors) |m| {
+            if (m.file_result != .ok) any_failures = true;
+            try out.print(" {} |", .{m.file_result});
+        }
+    }
+    try out.writeAll("\n| **Avg. time** | |");
+    for (mirrors) |*m| {
+        const avg_ns: u64 = if (m.ns_div == 0) 0 else m.total_ns / m.ns_div;
+        try out.print(" {} |", .{std.fmt.fmtDuration(avg_ns)});
+        // No need to reset, we're not doing any more checks
+    }
+
+    try out.writeByte('\n');
+
+    {
+        var out_file = std.fs.cwd().createFile(out_path, .{}) catch |err| {
+            std.debug.panic("failed to open output file '{s}': {s}", .{ out_path, @errorName(err) });
+        };
+        defer out_file.close();
+
+        out_file.writeAll(out_al.items) catch |err| {
+            std.debug.panic("failed to write output: {s}", .{@errorName(err)});
+        };
+    }
+
+    if (any_failures) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+fn checkFile(
+    gpa: Allocator,
+    arena: Allocator,
+    http_client: *std.http.Client,
+    /// Each mirror will have `file_result` populated.
+    /// If that result is `.ok`, `total_ns` and `ns_div` are also updated.
+    mirrors: []Mirror,
+    file: *const File,
+    prog_node: std.Progress.Node,
+) Allocator.Error!void {
+    const trusted_url = if (file.version) |version|
+        try std.fmt.allocPrint(arena, release_tarball_template, .{ version, file.name })
+    else
+        try std.fmt.allocPrint(arena, master_tarball_template, .{file.name});
+
+    const trusted_data = try httpGetZsf(gpa, http_client, trusted_url);
+    defer gpa.free(trusted_data);
+
+    var wg: std.Thread.WaitGroup = .{};
+
+    var oom: std.atomic.Value(bool) = .init(false);
+    for (mirrors) |*m| {
+        // `arena` isn't thread-safe, so alloc the URL now.
+        const url = try std.fmt.allocPrint(arena, "{s}/{s}", .{ m.url, file.name });
+        wg.spawnManager(
+            checkOneFile,
+            .{ gpa, http_client, m, url, trusted_data, &oom, prog_node },
+        );
+    }
+    wg.wait();
+    if (oom.raw) return error.OutOfMemory;
+}
+
+fn checkOneFile(
+    gpa: Allocator,
+    http_client: *std.http.Client,
+    mirror: *Mirror,
+    url: []const u8,
+    trusted_data: []const u8,
+    oom: *std.atomic.Value(bool),
+    prog_node: std.Progress.Node,
+) void {
+    const mirror_prog_node = prog_node.start(mirror.username, 0);
+    defer mirror_prog_node.end();
+    mirror.file_result = if (httpGet(gpa, http_client, url)) |get_result| switch (get_result) {
+        .success => |success| res: {
+            defer gpa.free(success.data);
+            if (std.mem.eql(u8, success.data, trusted_data)) {
+                mirror.total_ns += success.query_ns;
+                mirror.ns_div += 1;
+                break :res .{ .ok = success.query_ns };
+            } else {
+                break :res .content_mismatch;
+            }
+        },
+        .err => |err| .{ .err = err },
+        .bad_status => |s| .{ .bad_status = s },
+    } else |err| switch (err) {
+        error.OutOfMemory => return oom.store(true, .monotonic),
+    };
+}
+
+const GetResult = union(enum) {
+    err: anyerror,
+    bad_status: std.http.Status,
+    success: struct {
+        /// Allocated into `gpa`, caller must free
+        data: []u8,
+        query_ns: u64,
+    },
+};
+fn httpGet(
+    gpa: Allocator,
+    http_client: *std.http.Client,
+    url: []const u8,
+) Allocator.Error!GetResult {
+    var buf: std.ArrayList(u8) = .init(gpa);
+    defer buf.deinit();
+    var timer = std.time.Timer.start() catch @panic("std.time.Timer not supported");
+    const res = http_client.fetch(.{
+        .method = .GET,
+        .location = .{ .url = url },
+        .response_storage = .{ .dynamic = &buf },
+        .max_append_size = 512 * 1024 * 1024,
+    }) catch |err| return .{ .err = err };
+    if (res.status != .ok) {
+        return .{ .bad_status = res.status };
+    }
+    return .{ .success = .{
+        .data = try buf.toOwnedSlice(),
+        .query_ns = timer.read(),
+    } };
+}
+fn httpGetZsf(
+    gpa: Allocator,
+    http_client: *std.http.Client,
+    url: []const u8,
+) Allocator.Error![]u8 {
+    switch (try httpGet(gpa, http_client, url)) {
+        .err => |err| std.debug.panic("fetch '{s}' failed: {s}", .{ url, @errorName(err) }),
+        .bad_status => |status| std.debug.panic("fetch '{s}' failed: bad status: {d} {s}", .{ url, @intFromEnum(status), status.phrase() orelse "?" }),
+        .success => |res| return res.data,
+    }
+}
+
+const MasterTarballs = struct {
+    version: []const u8,
+    /// Every target (e.g. 'x86_64-linux', 'aarch64-macos') which a .tar.xz binary tarball exists for.
+    /// The tarball basename is 'zig-[target]-[version].tar.xz'.
+    tar_xz_targets: []const []const u8,
+    /// Every target (e.g. 'x86-windows') which a .zip binary tarball exists for.
+    /// The tarball basename is 'zig-[target]-[version].zip'.
+    zip_targets: []const []const u8,
+};
+
+fn parseMasterTarballs(arena: Allocator, root: *const std.json.Value) !MasterTarballs {
+    var tar_xz_targets: std.ArrayListUnmanaged([]const u8) = .empty;
+    var zip_targets: std.ArrayListUnmanaged([]const u8) = .empty;
+
+    if (root.* != .object) return error.RootNotObject;
+    const master_val = root.object.getPtr("master") orelse return error.DownloadMissingMaster;
+
+    if (master_val.* != .object) return error.MasterNotObject;
+    var master = try master_val.object.clone();
+
+    const version_val = (master.fetchSwapRemove("version") orelse return error.MasterMissingVersion).value;
+    if (version_val != .string) return error.VersionNotString;
+    const version_str = version_val.string;
+
+    _ = master.swapRemove("date");
+    _ = master.swapRemove("docs");
+    _ = master.swapRemove("stdDocs");
+    _ = master.swapRemove("src");
+    _ = master.swapRemove("bootstrap");
+
+    for (master.keys(), master.values()) |target_name, *val| {
+        if (val.* != .object) return error.BuildIsNotObject;
+        const tarball_url_val = val.object.getPtr("tarball") orelse return error.BuildMissingTarball;
+        if (tarball_url_val.* != .string) return error.TarballNotString;
+        const tarball_url = tarball_url_val.string;
+        if (std.mem.endsWith(u8, tarball_url, ".tar.xz")) {
+            try tar_xz_targets.append(arena, target_name);
+        } else if (std.mem.endsWith(u8, tarball_url, ".zip")) {
+            try zip_targets.append(arena, target_name);
+        } else {
+            return error.BadTarballExtension;
+        }
+    }
+    return .{
+        .version = version_str,
+        .tar_xz_targets = tar_xz_targets.items,
+        .zip_targets = zip_targets.items,
+    };
+}
+
+/// Asserts that `basename` is a valid release (i.e. *not* prerelease!) Zig tarball name.
+fn releaseTarballVersion(basename: []const u8) []const u8 {
+    assert(std.mem.startsWith(u8, basename, "zig-"));
+    const ext_len = if (std.mem.endsWith(u8, basename, ".tar.xz"))
+        ".tar.xz".len
+    else if (std.mem.endsWith(u8, basename, ".zip"))
+        ".zip".len
+    else
+        unreachable;
+    const stem = basename[0 .. basename.len - ext_len];
+    // `stem` is e.g. 'zig-x86_64-linux-0.14.1'
+    const i = std.mem.lastIndexOfScalar(u8, stem, '-').?;
+    const version = stem[i + 1 ..];
+    assert(std.ascii.isDigit(version[0]));
+    assert(std.ascii.isDigit(version[version.len - 1]));
+    assert(std.mem.count(u8, version, ".") == 2);
+    return version;
+}
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const ziggy = @import("ziggy");

--- a/check-mirrors/src/main.zig
+++ b/check-mirrors/src/main.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const check_mirrors = @import("check_mirrors");
+
+pub fn main() !void {
+    std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
+    try check_mirrors.bufferedPrint();
+}
+
+test "simple test" {
+    var list = std.ArrayList(i32).init(std.testing.allocator);
+    defer list.deinit(); // Try commenting this out and see if zig detects the memory leak!
+    try list.append(42);
+    try std.testing.expectEqual(@as(i32, 42), list.pop());
+}
+
+test "fuzz example" {
+    const Context = struct {
+        fn testOne(context: @This(), input: []const u8) anyerror!void {
+            _ = context;
+            try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input));
+        }
+    };
+    try std.testing.fuzz(Context{}, Context.testOne, .{});
+}

--- a/check-mirrors/src/root.zig
+++ b/check-mirrors/src/root.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+pub fn bufferedPrint() !void {
+    const stdout_file = std.io.getStdOut().writer();
+    var bw = std.io.bufferedWriter(stdout_file);
+    const stdout = bw.writer();
+
+    try stdout.print("Run `zig build test` to run the tests.\n", .{});
+
+    try bw.flush(); // Don't forget to flush!
+}
+
+pub fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+test "basic add functionality" {
+    try std.testing.expect(add(3, 7) == 10);
+}

--- a/content/en-US/download.smd
+++ b/content/en-US/download.smd
@@ -18,3 +18,6 @@ Files are signed with [minisign](https://jedisct1.github.io/minisign/) using thi
 ```
 RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ```
+
+> # [Setting up an automation?]($block)
+> If you're automating the process of downloading Zig, you might want to learn about [Community Mirrors](/download/community-mirrors) to avoid downtime and help us save on bandwidth costs.

--- a/content/en-US/download/community-mirrors.smd
+++ b/content/en-US/download/community-mirrors.smd
@@ -1,0 +1,91 @@
+---
+.title = "Community Mirrors",
+.author = "",
+.date = @date("2024-08-07:00:00:00"),
+.layout = "download/community-mirrors.shtml",
+.alternatives = [{
+    .name = "list",
+    .layout = "download/community-mirrors-list.shtml",
+    .output = "/download/community-mirrors.txt",
+}],
+.custom = { "mobile_menu_title": "Mirrors" },
+---
+
+If you're setting something up which will automatically download Zig, like CI, you might be interested in using community mirrors instead of downloading from
+ziglang.org.
+
+The ziglang.org website does not offer any uptime or speed guarantees, meaning that your CI will sporadically fail or have slower runs if it hardcodes it as a
+download URL. In fact, configuring your CI to fetch from ziglang.org directly contributes to uptime and speed issues, because this site is [intentionally hosted
+on a simple one-computer configuration](/news/migrate-to-self-hosting). Instead, it is often a good idea to fetch Zig from one of many community-maintained
+mirrors. These mirrors are not officially endorsed by the Zig Software Foundation, but they can be used without security risks thanks to our signing of
+archives. While no individual mirror has an uptime or speed guarantee, configuring your automation to cycle through the list of available mirrors can
+effectively guarantee high uptime in practice.
+
+> # [Security Notice]($block)
+> Community mirrors are not officially trusted or endorsed by the Zig Software Foundation, and could in theory serve malicious binaries. If you are using them,
+> you **must** make sure to validate the minisign signature for every tarball you download against the ZSF's public key, available on [the download
+> page](/download).
+
+## GitHub Actions
+
+If you are setting up an automation using GitHub Actions, you may be interested in the
+[mlugg/setup-zig](https://github.com/marketplace/actions/setup-zig-compiler) Action (note that this is not an official ZSF project). Not only does it install a
+Zig version of your choice from a community mirror, but it also saves your Zig cache directory between workflow runs, allowing for faster rebuilds.
+
+## Using Mirrors
+
+The list of community mirrors is available in a newline-separated ASCII text file at https://ziglang.org/download/community-mirrors.txt. Tooling is recommended
+to fetch this list and try mirrors in a randomized order (to avoid putting excessive load on any one mirror, as this slows it down for everyone).
+
+Every Zig tarball is associated with a [minisign](https://jedisct1.github.io/minisign/) signature file, which can also be downloaded from mirrors. **When you
+download a tarball from a mirror, you must also download its associated signature and verify the tarball against it.** Failing to check the signature could
+theoretically leave you vulnerable to malicious mirrors hosting modified tarballs.
+
+Put simply, the recommended strategy is approximately this pseudocode:
+
+```python
+pubkey = "(copy this from https://ziglang.org/download)"
+tarball_name = "zig-x86_64-linux-0.14.1.tar.xz"
+# To improve uptime, optionally cache this GET:
+mirrors = http_get("https://ziglang.org/download/community-mirrors.txt")
+# ASCII-encoded, one mirror per line, newlines are LF, there is a trailing newline.
+shuffled = shuffle_lines(mirrors)
+for mirror_url in shuffled:
+    tarball = http_get(f"{mirror_url}/{tarball_name}?source=my_automation_name")
+    if success:
+        # NEVER SKIP THIS STEP. The signature must be verified before the tarball is deemed safe.
+        signature = http_get(f"{mirror_url}/{tarball_name}.minisig?source=my_automation_name")
+        if success and minisign_verify(tarball, signature, pubkey):
+            print("Successfully fetched Zig 0.14.1!")
+```
+
+Because ziglang.org does not have guaranteed uptime, the `community-mirrors.txt` file may at times become inaccessible. For this reason, you may wish to
+consider caching its contents to prevent disruption in the event that ziglang.org encounters downtime. The recommended refetch interval is approximately
+once per day. At this point in time, mirrors may be added or removed on a monthly basis as the ecosystem evolves, so periodic re-fetching is essential.
+
+Written more precisely, here is the key information and recommend workflow for downloading Zig tarballs:
+
+* The mirror list file is available at https://ziglang.org/download/community-mirrors.txt.
+  * Because ziglang.org does not guarantee uptime, it may be desirable to cache this file.
+* The mirror list file contains ASCII-encoded mirror URLs, separated with newline characters (ASCII LF 0x20). There is a trailing newline. There is no other whitespace. There are no blank lines.
+* Mirrors are required to support HTTPS. Every line in the mirror list file begins with "https://".
+* Mirrors cannot guarantee uptime, so if one fails to serve you a tarball, you should try another. Ideally, shuffle the list, and try each mirror in turn.
+  * Usually, the first one will work. If no mirror works, you may choose to try `ziglang.org` as a final fallback.
+* To download a tarball from a mirror, perform a GET request to "mirror/filename", where "mirror" is the mirror URL, and "filename" is the basename of the corresponding tarball on ziglang.org (e.g. `zig-x86_64-linux-0.14.1.tar.xz`).
+  * You are highly encouraged to include in your request a query parameter named `source` containing a string indicating what is making this request. For instance, the `mlugg/setup-zig` GitHub Action passes it as `?source=github-mlugg-setup-zig`.
+  * Source tarballs, bootstrap tarballs, and binary tarballs are available from all listed mirrors, as well as minisign signatures for all such files.
+  * Binary tarballs for recent Zig versions are of the form `zig-x86_64-linux-0.14.1.tar.xz`.
+  * If a mirror responds with a HTTP status code other than 200 OK:
+    * `503 Unavilable` may indicate scheduled downtime.
+    * `429 Too Many Requests` may indicate intentional rate-limiting.
+    * `404 Not Found` is a permitted response when requesting Zig releses 0.5.0 or earlier, or Zig development builds earlier than the current latest release.
+    * Otherwise, feel free to [open an issue](https://github.com/ziglang/www.ziglang.org/issues/new) to inform us of the problem.
+* The Zig Software Foundation can never guarantee the security of any mirror, so every time a tarball is downloaded, it is **essential** to also download the minisign signature (suffix the filename with ".minisig") and verify it against the ZSF's public key (which you should copy from the ziglang.org/download page). **Never skip this step.**
+  * If a mirror responds with `200 OK` but signature validation fails on the returned tarball, feel free to [open an
+    issue](https://github.com/ziglang/www.ziglang.org/issues/new) to inform us of the problem.
+
+## Hosting a Mirror
+
+If you are interested in hosting a mirror, please consult the [documentation in the www.ziglang.org
+repository](https://github.com/ziglang/www.ziglang.org/blob/main/MIRRORS.md). Thank you for helping
+to improve and decentralize the Zig ecosystem!

--- a/layouts/download.shtml
+++ b/layouts/download.shtml
@@ -6,6 +6,22 @@
     rel="stylesheet"
     href="$site.asset('css/home.css').link()"
   >
+  <style>
+.block {
+  border: 2px solid grey;
+}
+.block h1 {
+  margin: 0;
+  font-size: 1.1em;
+  background: #f7a41d;
+  padding: 0.4em 0.7em;
+  color: black;
+}
+.block p {
+  margin: 0;
+  padding: 0.5em 0 0.5em 1.0em;
+}
+  </style>
 </head>
 <div id="content">
   <div class="container">

--- a/layouts/download/community-mirrors-list.shtml
+++ b/layouts/download/community-mirrors-list.shtml
@@ -1,0 +1,6 @@
+<ctx :loop="$site.asset('community-mirrors.ziggy').ziggy()"><ctx :text="$loop.it.get('url')"></ctx>
+</ctx><ctx :if="$page.draft">
+This file intentionally does not have a trailing newline in order to prevent a double-newline after
+the final mirror. If you modify this file, carefully inspect `community-mirrors.txt` to check you
+haven't made an unintentional change to the output.
+</ctx>

--- a/layouts/download/community-mirrors.shtml
+++ b/layouts/download/community-mirrors.shtml
@@ -1,0 +1,39 @@
+<extend template="locale.shtml">
+<title id="title" :text="$page.title"></title>
+<head id="head">
+  <link
+  type="text/css"
+  rel="stylesheet"
+  href="$site.asset('css/home.css').link()"
+>
+  <style>
+.block {
+  border: 2px solid grey;
+}
+.block h1 {
+  margin: 0;
+  font-size: 1.1em;
+  background: #f7a41d;
+  padding: 0.4em 0.7em;
+  color: black;
+}
+.block p {
+  margin: 0;
+  padding: 0.5em 0 0.5em 1.0em;
+}
+  </style>
+</head>
+<div id="content">
+  <div class="container">
+    <ctx back="$page.parentSection()">
+      <a id="back" href="$ctx.back.link()">
+        <ctx :text="$i18n.get('back')"></ctx>
+        <b :text="$ctx.back.title"></b>
+      </a>
+    </ctx>
+    <h1 class="title" :text="$page.title"></h1>
+    <ctx :if="$page.custom.get?('toc')" :html="$page.toc()">
+    </ctx>
+    <ctx :html="$page.content()"></ctx>
+  </div>
+</div>


### PR DESCRIPTION
The Zig tarball mirrors which were previously specific to the mlugg/setup-zig Action are now accessible on ziglang.org so that other tooling can use them.