### PR TITLE
New mirror: ziglang.freetls.fastly.net

### DIFF
--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -19,4 +19,9 @@
         .username = "silversquirl",
         .email = "silver@squirl.dev",
     },
+    {
+        .url = "https://ziglang.freetls.fastly.net",
+        .username = "jedisct1",
+        .email = "zigmirror@pureftpd.org",
+    },
 ]


### PR DESCRIPTION
This adds a new mirror running on the Fastly CDN.