### PR TITLE
Add zig.flozero.dev community mirror 

### DIFF
--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -19,4 +19,9 @@
         .username = "silversquirl",
         .email = "silver@squirl.dev",
     },
+    {
+        .url = "https://zig.florent.dev/zig",
+        .username = "flozero",
+        .email = "hello@florent.dev",
+    },
 ]

--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -20,7 +20,7 @@
         .email = "silver@squirl.dev",
     },
     {
-        .url = "https://zig.florent.dev/zig",
+        .url = "https://zig.florent.dev",
         .username = "flozero",
         .email = "hello@florent.dev",
     },


### PR DESCRIPTION
hosted in cloudflare I was looking to add a mirror different from what you have already.

Using r2 and worker for the cache logic base on the requirements

I intentionnally didn't pull a lot. If you want to see the live cache in action 

`https://zig.florent.dev/zig-aarch64-netbsd-0.15.0-dev.1092+d772c0627.tar.xz`

sorry for the branch name. Can re create it I just did it via the browser

