### PR TITLE
Fix German translation for "Maintain it with Zig"

### DIFF
--- a/content/de-DE/index.smd
+++ b/content/de-DE/index.smd
@@ -26,7 +26,7 @@ Ein moderner Ansatz zur Metaprogrammierung, basierend auf Compile-Zeit-Ausführu
 - Ändere Typen als Werte, ohne Laufzeitverlust.
 - Comptime emuliert die Zielarchitektur.
 
-## ⚡ Behalte alles in Zig
+## ⚡ Warte es mit Zig
 Verbessere schrittweise deine C/C++/Zig-Codebasis.
 
 - Verwende Zig als Drop-in-C/C++-Compiler ohne Abhängigkeiten, der sofort einsatzbereite Cross-Kompilierung unterstützt.


### PR DESCRIPTION
The current translation seems to be auto-generated. It currently states **_Keep everything in Zig_** because _maintain_ can also mean _keep_ in a different context. 
My proposed translation is an exact translation. "_Warte_" may sound a little weird to a German because it also means "_Wait!_", but I think it is still best here since it is the literal translation of _Maintain_. An alternative translation could be "_Pflege es mit Zig_" (_Care for it with Zig_).