### PR TITLE
check-mirrors: update to Zig 0.15.1

### DIFF
--- a/.github/workflows/check-mirrors.yml
+++ b/.github/workflows/check-mirrors.yml
@@ -16,8 +16,8 @@ jobs:
         # ziglang.org. This is **not** a recommended strategy for most users, but rather a special
         # case due to the role this repository plays in maintaining the mirror list.
         run: |
-          curl -L 'https://ziglang.org/builds/zig-x86_64-linux-0.15.0-dev.885+e83776595.tar.xz' | tar -xJ
-          mv 'zig-x86_64-linux-0.15.0-dev.885+e83776595' zig
+          curl -L 'https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz' | tar -xJ
+          mv 'zig-x86_64-linux-0.15.1' zig
           echo "$PWD/zig" >>"$GITHUB_PATH"
 
       - name: Check Mirrors

--- a/check-mirrors/build.zig.zon
+++ b/check-mirrors/build.zig.zon
@@ -2,11 +2,11 @@
     .name = .check_mirrors,
     .version = "0.0.0",
     .fingerprint = 0xcb408e1ecbee16fd, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .ziggy = .{
-            .url = "git+https://github.com/kristoff-it/ziggy.git#fe3bf9389e7ff213cf3548caaf9c6f3d4bb38647",
-            .hash = "ziggy-0.1.0-kTg8vwBEBgDFzbstERaPLr5TzM1DhfDza1we_eEXuLDL",
+            .url = "git+https://github.com/kristoff-it/ziggy#4353b20ef2ac750e35c6d68e4eb2a07c2d7cf901",
+            .hash = "ziggy-0.1.0-kTg8v5pABgDztlefWHceH-Sh8tVveguFC61QkmLkIRaA",
         },
     },
     .paths = .{


### PR DESCRIPTION
The (relatively recent) tarball we relied on was deleted from ziglang.org a few days ago, so the `check-mirrors` job has been failing since then. That means we need to upgrade to the new master build. ~~Unfortuantely, `std.http` is currently seriously regressed on Zig master, so this PR doesn't actually work yet. This fix is therefore blocked on ziglang/zig#24698. That PR being merged will require some more changes to the HTTP client usage here.~~

Update: we're on 0.15.1 now, which hopefully makes this mergeable... let's see!