### PR TITLE
Add Visual Studio plugin to tooling page

### DIFF
--- a/content/de-DE/learn/tools.smd
+++ b/content/de-DE/learn/tools.smd
@@ -20,6 +20,9 @@ Editor-spezifische Werkzeuge oder Erweiterungen, meist Syntax-Highlighter.
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/en-US/learn/tools.smd
+++ b/content/en-US/learn/tools.smd
@@ -20,6 +20,9 @@ Editor-specific tools, mostly syntax highlighters.
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/es-AR/learn/tools.smd
+++ b/content/es-AR/learn/tools.smd
@@ -20,6 +20,9 @@ Herramientas para editores específicos, principalmente marcado de sintaxis.
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/it-IT/learn/tools.smd
+++ b/content/it-IT/learn/tools.smd
@@ -20,6 +20,9 @@ Strumenti specifici per gli editor di testo, principalmente per evidenziare la s
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/ja-JP/learn/tools.smd
+++ b/content/ja-JP/learn/tools.smd
@@ -20,6 +20,9 @@
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/ko-KR/learn/tools.smd
+++ b/content/ko-KR/learn/tools.smd
@@ -22,6 +22,9 @@
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/ru-RU/learn/tools.smd
+++ b/content/ru-RU/learn/tools.smd
@@ -20,6 +20,9 @@
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/uk-UA/learn/tools.smd
+++ b/content/uk-UA/learn/tools.smd
@@ -20,6 +20,9 @@
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 

--- a/content/zh-CN/learn/tools.smd
+++ b/content/zh-CN/learn/tools.smd
@@ -20,6 +20,9 @@
 ## VS Code
 - [ziglang/vscode-zig](https://github.com/ziglang/vscode-zig)
 
+## Visual Studio
+- [ZigVS](https://marketplace.visualstudio.com/items?itemName=LuckystarStudio.ZigVS)
+
 ## Sublime Text
 - [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
 


### PR DESCRIPTION
Visual Studio (not VSCode) and feel it is useful and stable enough for wider use. Source is avaiable at https://github.com/luckystar-studio/ZigVS with a build published on Visual Studio Marketplace.
Added it below VS Code to keep them together but also considered listing at the bottom instead, please advise.