### PR TITLE
fixed 0.15.1 documentation pointing to 0.15.0 standard library

### DIFF
--- a/src/documentation/0.15.1/index.html
+++ b/src/documentation/0.15.1/index.html
@@ -789,7 +789,7 @@
       <h2 id="Zig-Standard-Library"><a href="#toc-Zig-Standard-Library">Zig Standard Library</a> <a class="hdr" href="#Zig-Standard-Library">§</a></h2>
 
       <p>
-        The <a href="https://ziglang.org/documentation/0.15.0/std/">Zig Standard Library</a> has its own documentation.
+        The <a href="https://ziglang.org/documentation/0.15.1/std/">Zig Standard Library</a> has its own documentation.
       </p>
       <p>
         Zig's Standard Library contains commonly used algorithms, data structures, and definitions to help you build programs or libraries.


### PR DESCRIPTION
It pointed to `https://ziglang.org/documentation/0.15.0/std/` instead of `https://ziglang.org/documentation/0.15.1/std/` and caused a 404