### PR TITLE
Fix outdated documentation for UpdateSourceFiles

### DIFF
--- a/content/en-US/learn/build-system.smd
+++ b/content/en-US/learn/build-system.smd
@@ -415,11 +415,7 @@ zig-out/
 It is uncommon, but sometimes the case that a project commits generated files
 into version control. This can be useful when the generated files are seldomly updated
 and have burdensome system dependencies for the update process, but *only* during the
-update process.
-
-For this, **WriteFiles** provides a way to accomplish this task. This is a feature that
-[will be extracted from WriteFiles into its own Build Step](https://github.com/ziglang/zig/issues/14944)
-in a future Zig version.
+update process. **UpdateSourceFiles** provides a way to accomplish this task.
 
 Be careful with this functionality; it should not be used during the normal
 build process, but as a utility run by a developer with intention to update


### PR DESCRIPTION
cb3fe1711b7e6c068da01a25aee412fcdd07d68e updated the example source code to use `UpdateSourceFiles` instead of `WriteFiles`, but failed to update the English description on the page. This updates the English description.