### PR TITLE
:iphone: fix release notes responsiveness

### DIFF
--- a/src/download/0.10.0/release-notes.html
+++ b/src/download/0.10.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.10.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.10.1/release-notes.html
+++ b/src/download/0.10.1/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.10.1 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.11.0/release-notes.html
+++ b/src/download/0.11.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.11.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.12.0/release-notes.html
+++ b/src/download/0.12.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.12.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.13.0/release-notes.html
+++ b/src/download/0.13.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.13.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.14.0/release-notes.html
+++ b/src/download/0.14.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.14.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.15.1/release-notes.html
+++ b/src/download/0.15.1/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.15.1 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.3.0/release-notes.html
+++ b/src/download/0.3.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.3.0 Release Notes &middot; The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="../../zig-icon.svg">
     <style type="text/css">
       #contents {

--- a/src/download/0.4.0/release-notes.html
+++ b/src/download/0.4.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.4.0 Release Notes &middot; The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style type="text/css">

--- a/src/download/0.5.0/release-notes.html
+++ b/src/download/0.5.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.5.0 Release Notes &middot; The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.6.0/release-notes.html
+++ b/src/download/0.6.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.6.0 Release Notes &middot; The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.7.0/release-notes.html
+++ b/src/download/0.7.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.7.0 Release Notes &middot; The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.7.1/release-notes.html
+++ b/src/download/0.7.1/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.7.1 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.8.0/release-notes.html
+++ b/src/download/0.8.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.8.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.8.1/release-notes.html
+++ b/src/download/0.8.1/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.8.1 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.9.0/release-notes.html
+++ b/src/download/0.9.0/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.9.0 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>

--- a/src/download/0.9.1/release-notes.html
+++ b/src/download/0.9.1/release-notes.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>0.9.1 Release Notes ⚡ The Zig Programming Language</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.png">
     <link rel="icon" href="/favicon.svg">
     <style>


### PR DESCRIPTION
On Firefox Focus on Android (can be tested also on Firefox Desktop with "Responsive design mode") the release notes does not scale making them hard to read.

Note that this does not affect Chrome on Android.

- [ ] I fixed it directly in the html, but I think that there should be a better place to fix this, where should this be fixed?
- [ ] How can I guarantee that upcoming release notes will have this `meta`?
- [ ] There are html under `old-content/` that does not have this meta too, should I fix them?