### PR TITLE
Add one more zig mirror

### DIFF
--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -54,4 +54,9 @@
         .username = "karearl",
         .email = "karearl@protonmail.com",
     },
+    {
+        .url = "https://mirror.govorov.online/zig",
+        .username = "mrdimidium",
+        .email = "me@govorov.online",
+    },
 ]


### PR DESCRIPTION
It's a small bare-metal mirror hosted in hetzner, caching and URL processing is fully implemented in Nginx.

DNS points directly to the server without balancers like cloudflare. It is vulnerable to malicious ddos ​​attacks, but should continue to work even in the event of a major failure at cloud providers.

I am ready to raise a few more instances in another regions and set up geodns if there is a need for this.