### PR TITLE
Add community mirror

### DIFF
--- a/MIRRORS.md
+++ b/MIRRORS.md
@@ -114,3 +114,4 @@ Some members of the Zig community have written software for hosting Zig mirrors,
 
 * [hexops/wrench](https://github.com/hexops/wrench?tab=readme-ov-file#run-your-own-ziglangorgdownload-mirror)
 * [silversquirl/bunny-cdn-instructions](https://gist.github.com/silversquirl/5c8d734ce8e5712eff8126295847e99f)
+* [inge4pres/zigmirror.com](https://github.com/inge4pres/zigmirror.com)

--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -34,4 +34,9 @@
         .username = "meox",
         .email = "glmeocci@gmail.com",
     },
+    {
+        .url = "https://zigmirror.com",
+        .username = "inge4pres",
+        .email = "francesco@zigmirror.com",
+    }
 ]


### PR DESCRIPTION
The mirror is geographically redundant and fast thanks to Cloudflare CDN.
Instructions to replicate the same setup are also added in MIRRORS.md.