### PR TITLE
feature(new_mirror): Added a community mirror: zig.savalione.com

### DIFF
--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -49,4 +49,9 @@
         .username = "jiacai2050",
         .email = "dev@liujiacai.net",
     },
+    {
+        .url = "https://zig.savalione.com",
+        .username = "savalione",
+        .email = "savelii.pototskii@gmail.com",
+    },
 ]


### PR DESCRIPTION
This adds a new community mirror hosted at `zig.savalione.com`.

The mirror is powered by a custom Go implementation and an Nginx configuration.
I plan to release the implementation and a guide on how to host a Zig mirror in the future.

I have tested several files and everything appears to be working correctly.
If you encounter any issues, please contact me at `savelii.pototskii@gmail.com`, and I will address them as quickly as possible.

Thanks for all your work on Zig!