### PR TITLE
Fix invalid code in 0.15.1 release notes

### DIFF
--- a/src/download/0.15.1/release-notes.html
+++ b/src/download/0.15.1/release-notes.html
@@ -1836,7 +1836,7 @@ while (it.next()) |header| {
 
 // Optimal size depends on how you will use the reader.
 var reader_buffer: [100]u8 = undefined;
-const body_reader = try response.reader(&reader_buffer);{#endsyntax#}</pre>
+const body_reader = response.reader(&reader_buffer);{#endsyntax#}</pre>
     {#header_close#}
 
     {#header_open|TLS Client#}


### PR DESCRIPTION
`try` shouldnt be needed here. Docs: try response.reader(&reader_buffer);