### PR TITLE
Fix 0.15.1 release notes to use `std.Io.Writer` instead of deprecated `std.io.Writer`

### DIFF
--- a/src/download/0.15.1/release-notes.html
+++ b/src/download/0.15.1/release-notes.html
@@ -1699,13 +1699,13 @@ try stdout.flush(); // Don't forget to flush!{#endsyntax#}</pre>
     writer: anytype,
 ) !void { ... }{#endsyntax#}</pre>
 <p>⬇️</p>
-<pre>{#syntax#}pub fn format(this: @This(), writer: *std.io.Writer) std.io.Writer.Error!void { ... }{#endsyntax#}</pre>
+<pre>{#syntax#}pub fn format(this: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void { ... }{#endsyntax#}</pre>
 <p>The deleted <code>FormatOptions</code> are now for numbers only.</p>
 <p>Any state that you got from the format string, there are three suggested alternatives:</p>
 <ol>
 <li>different format methods</li>
 </ol>
-<pre>{#syntax#}pub fn formatB(foo: Foo, writer: *std.io.Writer) std.io.Writer.Error!void { ... }{#endsyntax#}</pre>
+<pre>{#syntax#}pub fn formatB(foo: Foo, writer: *std.Io.Writer) std.Io.Writer.Error!void { ... }{#endsyntax#}</pre>
 <p>This can be called with {#syntax#}"{f}", .{std.fmt.alt(Foo, .formatB)}{#endsyntax#}.</p>
 <ol start="2">
 <li><code>std.fmt.Alt</code></li>
@@ -1715,7 +1715,7 @@ try stdout.flush(); // Don't forget to flush!{#endsyntax#}</pre>
 }
 const F = struct {
     context: i32,
-    pub fn baz(f: F, writer: *std.io.Writer) std.io.Writer.Error!void { ... }
+    pub fn baz(f: F, writer: *std.Io.Writer) std.Io.Writer.Error!void { ... }
 };{#endsyntax#}</pre>
 <p>This can be called with {#syntax#}"{f}", .{foo.bar(1234)}{#endsyntax#}.</p>
 <ol start="3">
@@ -1726,7 +1726,7 @@ const F = struct {
 }
 const F = struct {
     context: i32,
-    pub fn format(f: F, writer: *std.io.Writer) std.io.Writer.Error!void { ... }
+    pub fn format(f: F, writer: *std.Io.Writer) std.Io.Writer.Error!void { ... }
 };{#endsyntax#}</pre>
 <p>This can be called with {#syntax#}"{f}", .{foo.bar(1234)}{#endsyntax#}.</p>
     {#header_close#}


### PR DESCRIPTION
Replace occurrences of `std.io.Writer` with `std.Io.Writer` in the 0.15.1 release notes code examples.