### PR TITLE
Fix unintended compile error in build.zig example

### DIFF
--- a/zig-code/build-system/unit-testing/build.zig
+++ b/zig-code/build-system/unit-testing/build.zig
@@ -17,8 +17,10 @@ pub fn build(b: *std.Build) void {
 
     for (test_targets) |target| {
         const unit_tests = b.addTest(.{
-            .root_source_file = b.path("main.zig"),
-            .target = b.resolveTargetQuery(target),
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("main.zig"),
+                .target = b.resolveTargetQuery(target),
+            }),
         });
 
         const run_unit_tests = b.addRunArtifact(unit_tests);


### PR DESCRIPTION
As you can see at https://web.archive.org/web/20250924165935/https://ziglang.org/learn/build-system/#testing, this example failed to compile with:

```console
$ zig build test --summary all
/home/ci/actions-runner-website/_work/www.ziglang.org/www.ziglang.org/zig-code/build-system/unit-testing/build.zig:20:14: error: no field named 'root_source_file' in struct 'Build.TestOptions'
            .root_source_file = b.path("main.zig"),
             ^~~~~~~~~~~~~~~~
/home/ci/deps/zig-x86_64-linux-0.15.1/lib/std/Build.zig:856:25: note: struct declared here
pub const TestOptions = struct {
                        ^~~~~~
```

Despite the fact that this build.zig example apparently *should* fail to compile (since it contains `build=fail` at the end), this is clearly not the compile error that was intended. I'm sure of that because this example is followed by the diff that should be enough to fix the compile error:

https://github.com/ziglang/www.ziglang.org/blob/a69386eea1310f74551870d92250005eb49c191a/content/en-US/learn/build-system.smd#L240-L252

Therefore, this commit fixes the above compile error by following the build.zig example with this `skip_foreign_checks` patch applied: https://github.com/ziglang/www.ziglang.org/blob/a69386eea1310f74551870d92250005eb49c191a/zig-code/build-system/unit-testing-skip-foreign/build.zig#L20-L23