### PR TITLE
Fix link to undefined behavior documentation

### DIFF
--- a/content/en-US/learn/overview.smd
+++ b/content/en-US/learn/overview.smd
@@ -54,7 +54,7 @@ With Zig one can rely on a safety-enabled build mode, and selectively disable sa
 
 []($code.language('=html').buildAsset('features/3-undefined-behavior.zig'))
 
-Zig uses [undefined behavior](https://ziglang.org/documentation/master/#undefined) as a razor sharp tool for both bug prevention and performance enhancement.
+Zig uses [Illegal Behavior](https://ziglang.org/documentation/master/#Illegal-Behavior) as a razor sharp tool for both bug prevention and performance enhancement.
 
 Speaking of performance, Zig is faster than C.
 


### PR DESCRIPTION
The link of the undefined behavior  doesn't work, I don't know if it means to go to undefined or not