### PR TITLE
Change win.WINAPI into .winapi

### DIFF
--- a/zig-code/samples/windows-msgbox.zig
+++ b/zig-code/samples/windows-msgbox.zig
@@ -1,6 +1,6 @@
 const win = @import("std").os.windows;
 
-extern "user32" fn MessageBoxA(?win.HWND, [*:0]const u8, [*:0]const u8, u32) callconv(win.WINAPI) i32;
+extern "user32" fn MessageBoxA(?win.HWND, [*:0]const u8, [*:0]const u8, u32) callconv(.winapi) i32;
 
 pub fn main() !void {
     _ = MessageBoxA(null, "world!", "Hello", 0);


### PR DESCRIPTION
Simple switch from win.WINAPI to .winapi for compiler success.
Sample now compiles with Zig 0.15.2
