### PR TITLE
Zig Build System > Testing: fix code examples

### DIFF
--- a/zig-code/build-system/unit-testing-skip-foreign/build.zig
+++ b/zig-code/build-system/unit-testing-skip-foreign/build.zig
@@ -29,8 +29,7 @@ pub fn build(b: *std.Build) void {
     }
 }
 
-// zig-doctest: build-system --collapseable -- test --summary all
-
 // build=succeed
+// additional_option=test
 // additional_option=--summary
 // additional_option=all

--- a/zig-code/build-system/unit-testing-skip-foreign/main.zig
+++ b/zig-code/build-system/unit-testing-skip-foreign/main.zig
@@ -1,9 +1,13 @@
-// zig-doctest: syntax --name main
 const std = @import("std");
 
 test "simple test" {
-    var list = std.ArrayList(i32).init(std.testing.allocator);
-    defer list.deinit();
-    try list.append(42);
+    const allocator = std.testing.allocator;
+
+    var list: std.ArrayList(i32) = .empty;
+    defer list.deinit(allocator);
+
+    try list.append(allocator, 42);
     try std.testing.expectEqual(@as(i32, 42), list.pop());
 }
+
+// syntax

--- a/zig-code/build-system/unit-testing/main.zig
+++ b/zig-code/build-system/unit-testing/main.zig
@@ -1,9 +1,12 @@
 const std = @import("std");
 
 test "simple test" {
-    var list = std.ArrayList(i32).init(std.testing.allocator);
-    defer list.deinit();
-    try list.append(42);
+    const allocator = std.testing.allocator;
+
+    var list: std.ArrayList(i32) = .empty;
+    defer list.deinit(allocator);
+
+    try list.append(allocator, 42);
     try std.testing.expectEqual(@as(i32, 42), list.pop());
 }
 


### PR DESCRIPTION
This follows up on https://github.com/ziglang/www.ziglang.org/pull/545. Although it did fix one compile error, fixing it actually revealed other issues that are addressed by this pull request:

1. Both versions of `main.zig` were using the old `std.ArrayList` API from when it was managed, but as of Zig 0.15.1, it is no longer managed: https://ziglang.org/download/0.15.1/release-notes.html#ArrayList-make-unmanaged-the-default

2. The file `unit-testing-skip-foreign/build.zig` was missing `additional_option=test`, so the command `zig build --summary all` was run instead of the intended command `zig build test --summary all`.