### PR TITLE
Move mirror.govorov.online to pkg.earth

### DIFF
--- a/assets/community-mirrors.ziggy
+++ b/assets/community-mirrors.ziggy
@@ -55,9 +55,9 @@
         .email = "karearl@protonmail.com",
     },
     {
-        .url = "https://mirror.govorov.online/zig",
+        .url = "https://pkg.earth/zig",
         .username = "mrdimidium",
-        .email = "me@govorov.online",
+        .email = "mail@pkg.earth",
     },
     {
         .url = "https://fs.liujiacai.net/zigbuilds",


### PR DESCRIPTION
A beautiful domain came up, and I couldn't resist :)

Moved the one of community mirror to a separate domain, there are no more changes. The old domain will remain operational for a few weeks to allow all caches to update.