### PR TITLE
0.15.1 release notes: fix std.compress.flate code snippet

### DIFF
--- a/src/download/0.15.1/release-notes.html
+++ b/src/download/0.15.1/release-notes.html
@@ -1626,7 +1626,8 @@ var decompress: std.compress.flate.Decompress = .init(reader, .zlib, &decompress
 const decompress_reader: *std.Io.Reader = &decompress.reader;{#endsyntax#}</pre>
     <p>If <code>decompress_reader</code> will be piped entirely to a particular <code>*Writer</code>, then give it an empty buffer:</p>
     <pre>{#syntax#}var decompress: std.compress.flate.Decompress = .init(reader, .zlib, &.{});
-const n = try decompress.streamRemaining(writer);{#endsyntax#}</pre>
+const decompress_reader: *std.Io.Reader = &decompress.reader;
+const n = try decompress_reader.streamRemaining(writer);{#endsyntax#}</pre>
     <p>Compression functionality was removed. Sorry, you will have to copy the
     old code into your application, or use a third party package.</p>
     <p>It will be nice to get deflate back into the Zig standard library, but


### PR DESCRIPTION
`streamRemaining` is a method of `std.Io.Reader` (see https://ziglang.org/documentation/0.15.1/std/#std.Io.Reader.streamRemaining), not `std.compress.flate.Decompress`.

FWIW, I encountered this error when I tried to use `std.compress.flate.Decompress` in combination with `streamRemaining` in my code. Here's the final code that works on Zig 0.15.2: https://github.com/kaitai-io/kaitai_struct_zig_runtime/blob/d0aee404b6f3a8584ce4df57c52ce0425dc2ab8e/src/root.zig#L519-L526