### PR TITLE
Updated hello-world sample to 0.15.1-2

### DIFF
--- a/zig-code/samples/hello-world.zig
+++ b/zig-code/samples/hello-world.zig
@@ -1,7 +1,13 @@
 const std = @import("std");
 
 pub fn main() !void {
-    try std.fs.File.stdout().writeAll("hello world!\n");
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    
+    try stdout.print("hello world!\n", .{});
+    
+    try stdout.flush();
 }
 
 // exe=succeed


### PR DESCRIPTION
Hi, while the provided code still works, the function `writeAll` has been deprecated in favor of the writer interface:
https://ziglang.org/documentation/0.15.2/std/#std.fs.File.writeAll
I think it would be better to update this sample to either a "buffered print", like in this example, or a "unbuffered print".